### PR TITLE
wayland: make displaylink work with wlroots

### DIFF
--- a/home/mario/hosts/mli-pc.nix
+++ b/home/mario/hosts/mli-pc.nix
@@ -15,9 +15,7 @@
     plugin-list = ["!ConnectionNotifier"];
   };
 
-  wayland.windowManager.sway.extraOptions = [
-    "--unsupported-gpu"
-  ];
+  wayland.windowManager.sway.package = pkgs.sway-displaylink;
 
   mario.modules = {
     credentials = {

--- a/home/mario/hosts/mli-pc.nix
+++ b/home/mario/hosts/mli-pc.nix
@@ -15,6 +15,10 @@
     plugin-list = ["!ConnectionNotifier"];
   };
 
+  wayland.windowManager.sway.extraOptions = [
+    "--unsupported-gpu"
+  ];
+
   mario.modules = {
     credentials = {
       ssh.enable = true;

--- a/home/mario/modules/wayland/hyprland.nix
+++ b/home/mario/modules/wayland/hyprland.nix
@@ -29,7 +29,7 @@ in {
       };
 
       settings = let
-        hyprctl = "${pkgs.hyprland}/bin/hyprctl";
+        hyprctl = "${config.wayland.windowManager.hyprland.finalPackage}/bin/hyprctl";
         terminal = "${pkgs.alacritty}/bin/alacritty";
         browser = "${pkgs.firefox}/bin/firefox";
         editor = "emacsclient -c";
@@ -264,8 +264,8 @@ in {
     xdg.portal = {
       enable = true;
       xdgOpenUsePortal = true;
-      extraPortals = [pkgs.inputs.hyprland.xdg-desktop-portal-hyprland pkgs.xdg-desktop-portal-gtk];
-      configPackages = [pkgs.inputs.hyprland.hyprland];
+      extraPortals = [pkgs.hyprland.hyprland.xdg-desktop-portal-hyprland pkgs.xdg-desktop-portal-gtk];
+      configPackages = [pkgs.hyprland.hyprland];
       config = {
         common.default = ["*"];
         hyprland.default = ["gtk" "hyprland"];

--- a/home/mario/modules/wayland/locker.nix
+++ b/home/mario/modules/wayland/locker.nix
@@ -82,8 +82,8 @@ in {
       ];
 
       timeouts = let
-        hyprctl = "${pkgs.hyprland}/bin/hyprctl";
-        swaymsg = "${pkgs.sway}/bin/swaymsg";
+        hyprctl = "${config.wayland.windowManager.hyprland.finalPackage}/bin/hyprctl";
+        swaymsg = "${config.wayland.windowManager.sway.package}/bin/swaymsg";
       in
         [
           {

--- a/home/mario/modules/wayland/sway.nix
+++ b/home/mario/modules/wayland/sway.nix
@@ -30,8 +30,26 @@ in {
           scroll_button = "BTN_TASK";
         };
 
+        # TODO: Improve output management
         output."Unknown U34G2G4R3 0x0000241D" = {
           mode = "3440x1440@144.001Hz";
+        };
+
+        output."AU Optronics 0xED8F Unknown" = {
+          mode = "1920x1080@120.213Hz";
+          pos = "2126 1376";
+        };
+
+        output."Ancor Communications Inc VG248 LBLMQS291339" = {
+          mode = "1920x1080@60.0Hz";
+          pos = "187 0";
+          transform = "270";
+        };
+
+        output."Philips Consumer Electronics Company PHL 243S5L UK02111017301" = {
+          mode = "1920x1080@60.0Hz";
+          pos = "1267 296";
+          transform = "normal";
         };
 
         output."*" = {bg = "${outputs.wallpapers.city-lights.src} fill";};
@@ -246,7 +264,7 @@ in {
           "${mod}+p" = "exec rofi-rbw";
 
           # Clipboard
-          "${mod}+comma" = "clipman pick -t rofi -T'-theme ~/.config/rofi/themes/clipboard'";
+          "${mod}+comma" = "exec clipman pick -t rofi -T'-theme ~/.config/rofi/themes/clipboard'";
 
           # Screenshots
           "Print" = "exec grimshot --notify copy";

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -23,7 +23,7 @@ in {
   additions = final: _: import ../packages {pkgs = final;};
 
   # Overlays for various pkgs (e.g. broken, not updated)
-  modifications = final: prev: {
+  modifications = final: prev: rec {
     waybar = prev.waybar.overrideAttrs (oldAttrs: {
       mesonFlags = oldAttrs.mesonFlags ++ ["-Dexperimental=true"];
     });
@@ -47,6 +47,11 @@ in {
       .overrideAttrs (o: {
         pname = "${o.pname}-displaylink";
       });
+
+    xdg-desktop-portal-hyprland-displaylink = with inputs.hyprland.packages.${prev.system};
+      xdg-desktop-portal-hyprland.override {
+        hyprland = hyprland-displaylink;
+    };
 
     sway-displaylink = let
       wlroots-sway = prev.wlroots.overrideAttrs (_: {

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -78,6 +78,7 @@ in {
     in
       prev.sway.override {
         inherit sway-unwrapped;
+        extraOptions = ["--unsupported-gpu"];
       };
 
     # Keep this if telega is borked

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -41,8 +41,43 @@ in {
     });
 
     hyprland-displaylink = with inputs.hyprland.packages.${prev.system};
-      hyprland.override {
+      (hyprland.override {
         wlroots-hyprland = addPatches wlroots-hyprland [./displaylink.patch];
+      })
+      .overrideAttrs (o: {
+        pname = "${o.pname}-displaylink";
+      });
+
+    sway-displaylink = let
+      wlroots-sway = prev.wlroots.overrideAttrs (_: {
+        src = prev.fetchFromGitLab {
+          domain = "gitlab.freedesktop.org";
+          owner = "wlroots";
+          repo = "wlroots";
+          rev = "172c8add7dfae2853debe9cd70e41d736059e978";
+          sha256 = "sha256-VqvogF/g+hrf0D9DIXKg/oB3Z+79GVUobtLSB/aPWZE=";
+        };
+
+        patches = [
+          ./displaylink.patch
+        ];
+      });
+
+      sway-unwrapped =
+        (prev.sway-unwrapped.overrideAttrs (o: {
+          src = prev.fetchFromGitHub {
+            owner = "swaywm";
+            repo = "sway";
+            rev = "bc258a3be2f946c1c93bcbe40735b2db068e0ea8";
+            sha256 = "sha256-FTzDk2t1u3ckhBSLKB+rJSofc5wBYh3rGUffHkLRDco=";
+          };
+        }))
+        .override {
+          wlroots = wlroots-sway;
+        };
+    in
+      prev.sway.override {
+        inherit sway-unwrapped;
       };
 
     # Keep this if telega is borked

--- a/system/hosts/mli-pc/options.nix
+++ b/system/hosts/mli-pc/options.nix
@@ -4,6 +4,9 @@
   lib,
   ...
 }: {
+ 
+  programs.sway.package = pkgs.sway-displaylink;
+
   system.modules = {
     hardware = {
       audio.enable = true;

--- a/system/hosts/mli-pc/options.nix
+++ b/system/hosts/mli-pc/options.nix
@@ -1,13 +1,14 @@
 # Work laptop laptop
-{pkgs, ...}: {
-
-  programs.hyprland.package = lib.mkForce pkgs.hyprland-displaylink;
-
+{
+  pkgs,
+  lib,
+  ...
+}: {
   system.modules = {
     hardware = {
       audio.enable = true;
-      monitoring.enable = true;
       bluetooth.enable = true;
+      monitoring.enable = true;
       qmk.enable = true;
     };
 
@@ -24,10 +25,9 @@
     };
 
     graphical = {
-      gnome.enable = true;
       displaylink.enable = true;
-      # wayland.enable = true;
-      # greetd.enable = true;
+      wayland.enable = true;
+      greetd.enable = true;
     };
 
     core = {

--- a/system/modules/graphical/greetd.nix
+++ b/system/modules/graphical/greetd.nix
@@ -62,6 +62,6 @@ in {
       };
     };
 
-    services.greetd.settings.default_session.command = "${pkgs.sway}/bin/sway --config ${greetd-sway-config}";
+    services.greetd.settings.default_session.command = "${config.programs.sway.package}/bin/sway --config ${greetd-sway-config}";
   };
 }


### PR DESCRIPTION
## Changes

- Introduce displaylink patch for wlroots from [kennylevinsen](https://gitlab.freedesktop.org/kennylevinsen/wlroots/-/tree/displaylink-hack?ref_type=heads)
- Switch to Sway for `mli-pc` as Hyprland seems to have high CPU usage (maybe related to effects/animations)