### PR TITLE
emacs: refactor config to integrate setup.el and elpaca better

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Here I keep some stuff about Q CLI Developer, like a conversation I could need in future
+.amazon-q

--- a/home/mario/modules/editors/emacs/config/Emacs.org
+++ b/home/mario/modules/editors/emacs/config/Emacs.org
@@ -111,7 +111,8 @@ I also install [[https://github.com/radian-software/blackout][blackout.el]] (and
 
 #+begin_src emacs-lisp
 
-  (setup-pkg exec-path-from-shell
+  (setup exec-path-from-shell
+    (:elpaca t)
     (:only-if (eq system-type 'darwin))
     (:require exec-path-from-shell)
     (dolist (var '("SSH_AUTH_SOCK" "SSH_AGENT_PID" "GPG_AGENT_INFO" "LANG" "LC_CTYPE" "NIX_SSL_CERT_FILE" "NIX_PATH"))
@@ -601,7 +602,8 @@ My choice is [[https://github.com/vedang/pdf-tools][pdf-tools]], that renders on
 
 #+begin_src emacs-lisp
 
-  (setup-pkg (beancount-mode :host github :repo "beancount/beancount-mode" :main "beancount.el"))
+  (setup beancount-mode
+    (:elpaca :host github :repo "beancount/beancount-mode" :main "beancount.el"))
 
 #+end_src
 
@@ -648,7 +650,8 @@ Nice mode to control your system (and user) services without leaving Emacs.
 
 #+begin_src emacs-lisp
 
-  (setup-pkg daemons)
+  (setup daemons
+    (:elpaca t))
 
 #+end_src
 

--- a/home/mario/modules/editors/emacs/config/Emacs.org
+++ b/home/mario/modules/editors/emacs/config/Emacs.org
@@ -603,7 +603,7 @@ My choice is [[https://github.com/vedang/pdf-tools][pdf-tools]], that renders on
 #+begin_src emacs-lisp
 
   (setup beancount-mode
-    (:elpaca :host github :repo "beancount/beancount-mode" :main "beancount.el"))
+    (:elpaca (:host github :repo "beancount/beancount-mode" :main "beancount.el")))
 
 #+end_src
 

--- a/home/mario/modules/editors/emacs/config/Emacs.org
+++ b/home/mario/modules/editors/emacs/config/Emacs.org
@@ -112,7 +112,7 @@ I also install [[https://github.com/radian-software/blackout][blackout.el]] (and
 #+begin_src emacs-lisp
 
   (setup exec-path-from-shell
-    (:elpaca t)
+    (:pkg t)
     (:only-if (eq system-type 'darwin))
     (:require exec-path-from-shell)
     (dolist (var '("SSH_AUTH_SOCK" "SSH_AGENT_PID" "GPG_AGENT_INFO" "LANG" "LC_CTYPE" "NIX_SSL_CERT_FILE" "NIX_PATH"))
@@ -603,7 +603,7 @@ My choice is [[https://github.com/vedang/pdf-tools][pdf-tools]], that renders on
 #+begin_src emacs-lisp
 
   (setup beancount-mode
-    (:elpaca (:host github :repo "beancount/beancount-mode" :main "beancount.el")))
+    (:pkg (:host github :repo "beancount/beancount-mode" :main "beancount.el")))
 
 #+end_src
 
@@ -651,7 +651,7 @@ Nice mode to control your system (and user) services without leaving Emacs.
 #+begin_src emacs-lisp
 
   (setup daemons
-    (:elpaca t))
+    (:pkg t))
 
 #+end_src
 

--- a/home/mario/modules/editors/emacs/config/init.el
+++ b/home/mario/modules/editors/emacs/config/init.el
@@ -38,7 +38,7 @@
 (require 'init-setup)
 
 (setup exec-path-from-shell
-  (:elpaca t)
+  (:pkg t)
   (:only-if (eq system-type 'darwin))
   (:require exec-path-from-shell)
   (dolist (var '("SSH_AUTH_SOCK" "SSH_AGENT_PID" "GPG_AGENT_INFO" "LANG" "LC_CTYPE" "NIX_SSL_CERT_FILE" "NIX_PATH"))
@@ -120,7 +120,7 @@ t
 (require 'init-pdf)
 
 (setup beancount-mode
-  (:elpaca (:host github :repo "beancount/beancount-mode" :main "beancount.el")))
+  (:pkg (:host github :repo "beancount/beancount-mode" :main "beancount.el")))
 
 (require 'init-shell)
 
@@ -129,6 +129,6 @@ t
 (require 'init-media)
 
 (setup daemons
-  (:elpaca t))
+  (:pkg t))
 
 ;;; init.el ends here

--- a/home/mario/modules/editors/emacs/config/init.el
+++ b/home/mario/modules/editors/emacs/config/init.el
@@ -37,7 +37,8 @@
 ;; Require package management file
 (require 'init-setup)
 
-(setup-pkg exec-path-from-shell
+(setup exec-path-from-shell
+  (:elpaca t)
   (:only-if (eq system-type 'darwin))
   (:require exec-path-from-shell)
   (dolist (var '("SSH_AUTH_SOCK" "SSH_AGENT_PID" "GPG_AGENT_INFO" "LANG" "LC_CTYPE" "NIX_SSL_CERT_FILE" "NIX_PATH"))
@@ -118,7 +119,8 @@ t
 
 (require 'init-pdf)
 
-(setup-pkg (beancount-mode :host github :repo "beancount/beancount-mode" :main "beancount.el"))
+(setup beancount-mode
+  (:elpaca :host github :repo "beancount/beancount-mode" :main "beancount.el"))
 
 (require 'init-shell)
 
@@ -126,6 +128,7 @@ t
 
 (require 'init-media)
 
-(setup-pkg daemons)
+(setup daemons
+  (:elpaca t))
 
 ;;; init.el ends here

--- a/home/mario/modules/editors/emacs/config/init.el
+++ b/home/mario/modules/editors/emacs/config/init.el
@@ -120,7 +120,7 @@ t
 (require 'init-pdf)
 
 (setup beancount-mode
-  (:elpaca :host github :repo "beancount/beancount-mode" :main "beancount.el"))
+  (:elpaca (:host github :repo "beancount/beancount-mode" :main "beancount.el")))
 
 (require 'init-shell)
 

--- a/home/mario/modules/editors/emacs/config/lisp/init-appearance.el
+++ b/home/mario/modules/editors/emacs/config/lisp/init-appearance.el
@@ -43,7 +43,7 @@
 
 ;; You must run `all-the-icons-install-fonts` the first time.
 (setup all-the-icons
-  (:elpaca t)
+  (:pkg t)
   (:require all-the-icons))
 
 (provide 'init-appearance)

--- a/home/mario/modules/editors/emacs/config/lisp/init-appearance.el
+++ b/home/mario/modules/editors/emacs/config/lisp/init-appearance.el
@@ -42,7 +42,8 @@
   (setq-default indicate-buffer-boundaries nil))
 
 ;; You must run `all-the-icons-install-fonts` the first time.
-(setup-pkg all-the-icons
+(setup all-the-icons
+  (:elpaca t)
   (:require all-the-icons))
 
 (provide 'init-appearance)

--- a/home/mario/modules/editors/emacs/config/lisp/init-code-style.el
+++ b/home/mario/modules/editors/emacs/config/lisp/init-code-style.el
@@ -7,12 +7,14 @@
 
 ;;; Code:
 
-(setup-pkg format-all
+(setup format-all
+  (:elpaca t)
   (:hide-mode)
   (:hook-into prog-mode)
   (:global "<f1>" format-all-buffer))
 
-(setup-pkg editorconfig
+(setup editorconfig
+  (:elpaca t)
   (:hide-mode)
   (editorconfig-mode 1))
 
@@ -20,10 +22,12 @@
   (:hide-mode)
   (global-eldoc-mode 1))
 
-(setup-pkg rainbow-mode
+(setup rainbow-mode
+  (:elpaca t)
   (:hook-into web-mode json-mode))
 
-(setup-pkg ws-butler
+(setup ws-butler
+  (:elpaca t)
   (:require)
   (:hook-into prog-mode)
   (:option mode-require-final-newline t
@@ -36,16 +40,19 @@
            tab-width 2
            indent-tabs-mode nil)) ; Use spaces!
 
-(setup-pkg rainbow-delimiters
+(setup rainbow-delimiters
+  (:elpaca t)
   (:hook-into prog-mode))
 
+;; FIXME: What the hell is this...
 (if (and (version< "29" emacs-version) (treesit-available-p))
 
     (progn
       (setup treesit
         (:option treesit-font-lock-level 4))
 
-      (setup-pkg treesit-auto
+      (setup treesit-auto
+        (:elpaca t)
         (:load-after treesit)
         (:autoload global-treesit-auto-mode)
 
@@ -54,10 +61,12 @@
 
   (progn
 
-    (setup-pkg tree-sitter-langs
+    (setup tree-sitter-langs
+      (:elpaca t)
       (:load-after tree-sitter-langs))
 
-    (setup-pkg tree-sitter
+    (setup tree-sitter
+      (:elpaca t)
       (:load-after tree-sitter-langs)
 
       (:autoload tree-sitter-mode tree-sitter-hl-mode)

--- a/home/mario/modules/editors/emacs/config/lisp/init-code-style.el
+++ b/home/mario/modules/editors/emacs/config/lisp/init-code-style.el
@@ -8,13 +8,13 @@
 ;;; Code:
 
 (setup format-all
-  (:elpaca t)
+  (:pkg t)
   (:hide-mode)
   (:hook-into prog-mode)
   (:global "<f1>" format-all-buffer))
 
 (setup editorconfig
-  (:elpaca t)
+  (:pkg t)
   (:hide-mode)
   (editorconfig-mode 1))
 
@@ -23,11 +23,11 @@
   (global-eldoc-mode 1))
 
 (setup rainbow-mode
-  (:elpaca t)
+  (:pkg t)
   (:hook-into web-mode json-mode))
 
 (setup ws-butler
-  (:elpaca t)
+  (:pkg t)
   (:require)
   (:hook-into prog-mode)
   (:option mode-require-final-newline t
@@ -41,7 +41,7 @@
            indent-tabs-mode nil)) ; Use spaces!
 
 (setup rainbow-delimiters
-  (:elpaca t)
+  (:pkg t)
   (:hook-into prog-mode))
 
 ;; FIXME: What the hell is this...
@@ -52,7 +52,7 @@
         (:option treesit-font-lock-level 4))
 
       (setup treesit-auto
-        (:elpaca t)
+        (:pkg t)
         (:load-after treesit)
         (:autoload global-treesit-auto-mode)
 
@@ -62,11 +62,11 @@
   (progn
 
     (setup tree-sitter-langs
-      (:elpaca t)
+      (:pkg t)
       (:load-after tree-sitter-langs))
 
     (setup tree-sitter
-      (:elpaca t)
+      (:pkg t)
       (:load-after tree-sitter-langs)
 
       (:autoload tree-sitter-mode tree-sitter-hl-mode)

--- a/home/mario/modules/editors/emacs/config/lisp/init-complete-in-buffer.el
+++ b/home/mario/modules/editors/emacs/config/lisp/init-complete-in-buffer.el
@@ -7,8 +7,8 @@
 ;;; Code:
 
 (setup corfu
-  (:elpaca :files (:defaults "extensions/*")
-           :includes (corfu-history corfu-popupinfo corfu-info))
+  (:elpaca (:files (:defaults "extensions/*")
+                   :includes (corfu-history corfu-popupinfo corfu-info)))
   (:option corfu-cycle t
            corfu-auto t
            corfu-auto-delay 0.3

--- a/home/mario/modules/editors/emacs/config/lisp/init-complete-in-buffer.el
+++ b/home/mario/modules/editors/emacs/config/lisp/init-complete-in-buffer.el
@@ -7,7 +7,7 @@
 ;;; Code:
 
 (setup corfu
-  (:elpaca (:files (:defaults "extensions/*")
+  (:pkg (:files (:defaults "extensions/*")
                    :includes (corfu-history corfu-popupinfo corfu-info)))
   (:option corfu-cycle t
            corfu-auto t
@@ -103,17 +103,17 @@ Useful for prompts such as `eval-expression' and `shell-command'."
       "M-l" corfu-info-location)))
 
 (setup kind-icon
-  (:elpaca t)
+  (:pkg t)
   (:with-after corfu
     (:option kind-icon-default-face 'corfu-default
              kind-icon-default-style '(:padding 0 :stroke 0 :margin 0 :radius 0 :height 0.7 :scale 1.0))
     (add-to-list 'corfu-margin-formatters #'kind-icon-margin-formatter)))
 
 (setup cape
-  (:elpaca t)
+  (:pkg t)
   ;; Needed for company-backends!
   (setup company
-  (:elpaca t)
+  (:pkg t)
     (:autoload company-grab))
 
   (dolist (backend '(cape-elisp-symbol cape-keyword cape-file cape-history cape-dabbrev))

--- a/home/mario/modules/editors/emacs/config/lisp/init-complete-in-buffer.el
+++ b/home/mario/modules/editors/emacs/config/lisp/init-complete-in-buffer.el
@@ -6,8 +6,9 @@
 
 ;;; Code:
 
-(setup-pkg (corfu :files (:defaults "extensions/*")
-                  :includes (corfu-history corfu-popupinfo corfu-info))
+(setup corfu
+  (:elpaca :files (:defaults "extensions/*")
+           :includes (corfu-history corfu-popupinfo corfu-info))
   (:option corfu-cycle t
            corfu-auto t
            corfu-auto-delay 0.3
@@ -101,15 +102,18 @@ Useful for prompts such as `eval-expression' and `shell-command'."
       "M-d" corfu-info-documentation
       "M-l" corfu-info-location)))
 
-(setup-pkg kind-icon
+(setup kind-icon
+  (:elpaca t)
   (:with-after corfu
     (:option kind-icon-default-face 'corfu-default
              kind-icon-default-style '(:padding 0 :stroke 0 :margin 0 :radius 0 :height 0.7 :scale 1.0))
     (add-to-list 'corfu-margin-formatters #'kind-icon-margin-formatter)))
 
-(setup-pkg cape
+(setup cape
+  (:elpaca t)
   ;; Needed for company-backends!
-  (setup-pkg company
+  (setup company
+  (:elpaca t)
     (:autoload company-grab))
 
   (dolist (backend '(cape-elisp-symbol cape-keyword cape-file cape-history cape-dabbrev))

--- a/home/mario/modules/editors/emacs/config/lisp/init-complete.el
+++ b/home/mario/modules/editors/emacs/config/lisp/init-complete.el
@@ -49,7 +49,8 @@
     (:hook savehist-mode)))
 
 ;; Vertico
-(setup-pkg (vertico :files (:defaults "extensions/*"))
+(setup vertico
+  (:elpaca :files (:defaults "extensions/*"))
 
   (:also-load vertico-indexed
               vertico-flat
@@ -113,7 +114,8 @@
   (vertico-multiform-mode 1))
 
 ;; Marginalia
-(setup-pkg marginalia
+(setup marginalia
+  (:elpaca t)
   (:load-after vertico)
   (:with-map minibuffer-local-map
     (:bind
@@ -122,17 +124,19 @@
 
 ;; TODO: Remove fork when https://github.com/iyefrat/all-the-icons-completion/pull/33 is merged
 ;; TODO: Then, remove direct reference to GitHub when on MELPA
-(setup-pkg (all-the-icons-completion :host github :repo "iyefrat/all-the-icons-completion"
-                                       :remotes ("fork"
-                                                 :repo "maxecharel/all-the-icons-completion"
-                                                 :branch "contrib"))
+(setup all-the-icons-completion
+  (:elpaca :host github :repo "iyefrat/all-the-icons-completion"
+           :remotes ("fork"
+                     :repo "maxecharel/all-the-icons-completion"
+                     :branch "contrib"))
   (:with-after (all-the-icons marginalia)
     (all-the-icons-completion-mode 1)
     (:with-mode marginalia-mode
       (:hook all-the-icons-completion-marginalia-setup))))
 
 ;; Orderless
-(setup-pkg orderless
+(setup orderless
+  (:elpaca t)
   (defun archer-orderless-literal-dispatcher (pattern _index _total)
     "Literal style dispatcher, using equal sign as a suffix."
     (cond

--- a/home/mario/modules/editors/emacs/config/lisp/init-complete.el
+++ b/home/mario/modules/editors/emacs/config/lisp/init-complete.el
@@ -50,7 +50,7 @@
 
 ;; Vertico
 (setup vertico
-  (:elpaca :files (:defaults "extensions/*"))
+  (:elpaca (:files (:defaults "extensions/*")))
 
   (:also-load vertico-indexed
               vertico-flat
@@ -125,10 +125,10 @@
 ;; TODO: Remove fork when https://github.com/iyefrat/all-the-icons-completion/pull/33 is merged
 ;; TODO: Then, remove direct reference to GitHub when on MELPA
 (setup all-the-icons-completion
-  (:elpaca :host github :repo "iyefrat/all-the-icons-completion"
-           :remotes ("fork"
-                     :repo "maxecharel/all-the-icons-completion"
-                     :branch "contrib"))
+  (:elpaca (:host github :repo "iyefrat/all-the-icons-completion"
+                  :remotes ("fork"
+                            :repo "maxecharel/all-the-icons-completion"
+                            :branch "contrib")))
   (:with-after (all-the-icons marginalia)
     (all-the-icons-completion-mode 1)
     (:with-mode marginalia-mode

--- a/home/mario/modules/editors/emacs/config/lisp/init-complete.el
+++ b/home/mario/modules/editors/emacs/config/lisp/init-complete.el
@@ -50,7 +50,7 @@
 
 ;; Vertico
 (setup vertico
-  (:elpaca (:files (:defaults "extensions/*")))
+  (:pkg (:files (:defaults "extensions/*")))
 
   (:also-load vertico-indexed
               vertico-flat
@@ -115,7 +115,7 @@
 
 ;; Marginalia
 (setup marginalia
-  (:elpaca t)
+  (:pkg t)
   (:load-after vertico)
   (:with-map minibuffer-local-map
     (:bind
@@ -125,7 +125,7 @@
 ;; TODO: Remove fork when https://github.com/iyefrat/all-the-icons-completion/pull/33 is merged
 ;; TODO: Then, remove direct reference to GitHub when on MELPA
 (setup all-the-icons-completion
-  (:elpaca (:host github :repo "iyefrat/all-the-icons-completion"
+  (:pkg (:host github :repo "iyefrat/all-the-icons-completion"
                   :remotes ("fork"
                             :repo "maxecharel/all-the-icons-completion"
                             :branch "contrib")))
@@ -136,7 +136,7 @@
 
 ;; Orderless
 (setup orderless
-  (:elpaca t)
+  (:pkg t)
   (defun archer-orderless-literal-dispatcher (pattern _index _total)
     "Literal style dispatcher, using equal sign as a suffix."
     (cond

--- a/home/mario/modules/editors/emacs/config/lisp/init-consult.el
+++ b/home/mario/modules/editors/emacs/config/lisp/init-consult.el
@@ -6,7 +6,8 @@
 
 ;;; Code:
 
-(setup-pkg consult
+(setup consult
+  (:elpaca t)
   (:require consult)
 
   ;; C-c bindings (mode specific)
@@ -111,7 +112,8 @@
   (:with-mode completion-list-mode
     (:hook consult-preview-at-point-mode)))
 
-(setup-pkg consult-dir
+(setup consult-dir
+  (:elpaca t)
   (:with-after consult
     (:global "C-x C-d" consult-dir)
     (:with-map minibuffer-local-completion-map
@@ -119,7 +121,8 @@
        "C-x C-d" consult-dir-maybe
        "C-x C-j" consult-dir-jump-file))))
 
-(setup-pkg consult-eglot
+(setup consult-eglot
+  (:elpaca t)
   (:with-after (consult eglot)
     (:global "M-g s" consult-eglot-symbols)))
 

--- a/home/mario/modules/editors/emacs/config/lisp/init-consult.el
+++ b/home/mario/modules/editors/emacs/config/lisp/init-consult.el
@@ -7,7 +7,7 @@
 ;;; Code:
 
 (setup consult
-  (:elpaca t)
+  (:pkg t)
   (:require consult)
 
   ;; C-c bindings (mode specific)
@@ -113,7 +113,7 @@
     (:hook consult-preview-at-point-mode)))
 
 (setup consult-dir
-  (:elpaca t)
+  (:pkg t)
   (:with-after consult
     (:global "C-x C-d" consult-dir)
     (:with-map minibuffer-local-completion-map
@@ -122,7 +122,7 @@
        "C-x C-j" consult-dir-jump-file))))
 
 (setup consult-eglot
-  (:elpaca t)
+  (:pkg t)
   (:with-after (consult eglot)
     (:global "M-g s" consult-eglot-symbols)))
 

--- a/home/mario/modules/editors/emacs/config/lisp/init-dash.el
+++ b/home/mario/modules/editors/emacs/config/lisp/init-dash.el
@@ -7,7 +7,7 @@
 ;;; Code:
 
 (setup dashboard
-  (:elpaca t)
+  (:pkg t)
   (:option dashboard-banner-logo-title "SUCK(EMAC)S - Personal Workspace"
            dashboard-startup-banner (expand-file-name "img/stallman.png" user-emacs-directory)
            dashboard-center-content t

--- a/home/mario/modules/editors/emacs/config/lisp/init-dash.el
+++ b/home/mario/modules/editors/emacs/config/lisp/init-dash.el
@@ -6,7 +6,8 @@
 
 ;;; Code:
 
-(setup-pkg dashboard
+(setup dashboard
+  (:elpaca t)
   (:option dashboard-banner-logo-title "SUCK(EMAC)S - Personal Workspace"
            dashboard-startup-banner (expand-file-name "img/stallman.png" user-emacs-directory)
            dashboard-center-content t

--- a/home/mario/modules/editors/emacs/config/lisp/init-dired.el
+++ b/home/mario/modules/editors/emacs/config/lisp/init-dired.el
@@ -72,11 +72,13 @@
   (:with-map image-dired-thumbnail-mode-map
     (:bind "<return>" #'image-dired-thumbnail-display-external)))
 
-(setup-pkg diredfl
-  :disabled
+(setup diredfl
+  (:quit)
+  (:elpaca t)
   (diredfl-global-mode 1))
 
-(setup-pkg dired-subtree
+(setup dired-subtree
+  (:elpaca t)
   (:load-after dired)
   (:option dired-subtree-use-backgrounds nil)
   (:with-map dired-mode-map
@@ -84,20 +86,24 @@
       "<tab>" dired-subtree-toggle
       "<backtab>" dired-subtree-remove)))
 
-(setup-pkg dired-sidebar
+(setup dired-sidebar
+  (:elpaca t)
   (:load-after dired)
   (:global "C-x C-n" dired-sidebar-toggle-sidebar))
 
-(setup-pkg dired-collapse
+(setup dired-collapse
+  (:elpaca t)
   (:with-after dired
     (:hook-into dired-mode-hook)))
 
-(setup-pkg all-the-icons-dired
+(setup all-the-icons-dired
+  (:elpaca t)
   (:option all-the-icons-dired-monochrome nil)
   (:with-after (all-the-icons dired)
     (:hook-into dired-mode-hook)))
 
-(setup-pkg trashed
+(setup trashed
+  (:elpaca t)
   (:option trashed-action-confirmer 'y-or-n-p
            trashed-use-header-line t
            trashed-sort-key '("Date deleted" . t)))

--- a/home/mario/modules/editors/emacs/config/lisp/init-dired.el
+++ b/home/mario/modules/editors/emacs/config/lisp/init-dired.el
@@ -74,11 +74,11 @@
 
 (setup diredfl
   (:disable t)
-  (:elpaca t)
+  (:pkg t)
   (diredfl-global-mode 1))
 
 (setup dired-subtree
-  (:elpaca t)
+  (:pkg t)
   (:load-after dired)
   (:option dired-subtree-use-backgrounds nil)
   (:with-map dired-mode-map
@@ -87,23 +87,23 @@
       "<backtab>" dired-subtree-remove)))
 
 (setup dired-sidebar
-  (:elpaca t)
+  (:pkg t)
   (:load-after dired)
   (:global "C-x C-n" dired-sidebar-toggle-sidebar))
 
 (setup dired-collapse
-  (:elpaca t)
+  (:pkg t)
   (:with-after dired
     (:hook-into dired-mode-hook)))
 
 (setup all-the-icons-dired
-  (:elpaca t)
+  (:pkg t)
   (:option all-the-icons-dired-monochrome nil)
   (:with-after (all-the-icons dired)
     (:hook-into dired-mode-hook)))
 
 (setup trashed
-  (:elpaca t)
+  (:pkg t)
   (:option trashed-action-confirmer 'y-or-n-p
            trashed-use-header-line t
            trashed-sort-key '("Date deleted" . t)))

--- a/home/mario/modules/editors/emacs/config/lisp/init-dired.el
+++ b/home/mario/modules/editors/emacs/config/lisp/init-dired.el
@@ -73,7 +73,7 @@
     (:bind "<return>" #'image-dired-thumbnail-display-external)))
 
 (setup diredfl
-  (:quit)
+  (:disable t)
   (:elpaca t)
   (diredfl-global-mode 1))
 

--- a/home/mario/modules/editors/emacs/config/lisp/init-editing.el
+++ b/home/mario/modules/editors/emacs/config/lisp/init-editing.el
@@ -111,7 +111,7 @@
         scroll-preserve-screen-position t))
 
 (setup ultra-scroll
-  (:elpaca :host github :repo "jdtsmith/ultra-scroll")
+  (:elpaca (:host github :repo "jdtsmith/ultra-scroll"))
   (:option scroll-conservatively 101
            scroll-margin 0)
   (:when-loaded

--- a/home/mario/modules/editors/emacs/config/lisp/init-editing.el
+++ b/home/mario/modules/editors/emacs/config/lisp/init-editing.el
@@ -31,7 +31,8 @@
 ;;; Keep history and keep the order
 
 ;; The `no-littering` package to keep folders where we edit files and the Emacs configuration folder clean.
-(setup-pkg no-littering
+(setup no-littering
+  (:elpaca t)
   ;; The package doesn't set this by default so we must place
   ;; auto save files in the same path as it uses for sessions
   (:option auto-save-file-name-transforms `((".*" ,(no-littering-expand-var-file-name "auto-save/")))))
@@ -109,7 +110,8 @@
         scroll-preserve-screen-position t
         scroll-preserve-screen-position t))
 
-(setup-pkg (ultra-scroll :host github :repo "jdtsmith/ultra-scroll")
+(setup ultra-scroll
+  (:elpaca :host github :repo "jdtsmith/ultra-scroll")
   (:option scroll-conservatively 101
            scroll-margin 0)
   (:when-loaded
@@ -154,12 +156,14 @@
   (:with-hook after-init-hook
     (:hook delete-selection-mode)))
 
-(setup-pkg drag-stuff
+(setup drag-stuff
+  (:elpaca t)
   (:hide-mode)
   (drag-stuff-global-mode 1)
   (drag-stuff-define-keys))
 
-(setup-pkg goto-last-change
+(setup goto-last-change
+  (:elpaca t)
   (:global "C-z" goto-last-change))
 
 (setup (:require autorevert)
@@ -172,7 +176,8 @@
 (setup (:require so-long)
   (global-so-long-mode 1))
 
-(setup-pkg diff-hl
+(setup diff-hl
+  (:elpaca t)
   (:hook-into prog-mode)
 
   (:with-mode dired-mode

--- a/home/mario/modules/editors/emacs/config/lisp/init-editing.el
+++ b/home/mario/modules/editors/emacs/config/lisp/init-editing.el
@@ -32,7 +32,7 @@
 
 ;; The `no-littering` package to keep folders where we edit files and the Emacs configuration folder clean.
 (setup no-littering
-  (:elpaca t)
+  (:pkg t)
   ;; The package doesn't set this by default so we must place
   ;; auto save files in the same path as it uses for sessions
   (:option auto-save-file-name-transforms `((".*" ,(no-littering-expand-var-file-name "auto-save/")))))
@@ -111,7 +111,7 @@
         scroll-preserve-screen-position t))
 
 (setup ultra-scroll
-  (:elpaca (:host github :repo "jdtsmith/ultra-scroll"))
+  (:pkg (:host github :repo "jdtsmith/ultra-scroll"))
   (:option scroll-conservatively 101
            scroll-margin 0)
   (:when-loaded
@@ -157,13 +157,13 @@
     (:hook delete-selection-mode)))
 
 (setup drag-stuff
-  (:elpaca t)
+  (:pkg t)
   (:hide-mode)
   (drag-stuff-global-mode 1)
   (drag-stuff-define-keys))
 
 (setup goto-last-change
-  (:elpaca t)
+  (:pkg t)
   (:global "C-z" goto-last-change))
 
 (setup (:require autorevert)
@@ -177,7 +177,7 @@
   (global-so-long-mode 1))
 
 (setup diff-hl
-  (:elpaca t)
+  (:pkg t)
   (:hook-into prog-mode)
 
   (:with-mode dired-mode

--- a/home/mario/modules/editors/emacs/config/lisp/init-embark.el
+++ b/home/mario/modules/editors/emacs/config/lisp/init-embark.el
@@ -44,7 +44,7 @@ targets."
 
 ;; Embark configuration
 (setup embark
-  (:elpaca t)
+  (:pkg t)
   (:with-after consult
     (elpaca embark-consult))
 
@@ -64,7 +64,7 @@ targets."
 
 ;; Used for export and edit after ripgrep magic.
 (setup wgrep
-  (:elpaca t))
+  (:pkg t))
 
 (provide 'init-embark)
 ;;; init-embark.el ends here

--- a/home/mario/modules/editors/emacs/config/lisp/init-embark.el
+++ b/home/mario/modules/editors/emacs/config/lisp/init-embark.el
@@ -43,7 +43,8 @@ targets."
     (apply fn args)))
 
 ;; Embark configuration
-(setup-pkg embark
+(setup embark
+  (:elpaca t)
   (:with-after consult
     (elpaca embark-consult))
 
@@ -62,7 +63,8 @@ targets."
                  (window-parameters (mode-line-format . none)))))
 
 ;; Used for export and edit after ripgrep magic.
-(setup-pkg wgrep)
+(setup wgrep
+  (:elpaca t))
 
 (provide 'init-embark)
 ;;; init-embark.el ends here

--- a/home/mario/modules/editors/emacs/config/lisp/init-extra-modes.el
+++ b/home/mario/modules/editors/emacs/config/lisp/init-extra-modes.el
@@ -7,33 +7,33 @@
 ;;; Code:
 
 (setup cmake-mode
-  (:elpaca t)
+  (:pkg t)
   (:file-match (rx (or "CmakeLists.txt" ".cmake") eos)))
 
 (setup nix-mode
-  (:elpaca t)
+  (:pkg t)
   (:file-match (rx ".nix" eos)))
 
 (setup markdown-mode
-  (:elpaca t)
+  (:pkg t)
   (:file-match (rx (or ".md" ".markdown" ".mdown") eos)))
 
 (setup yaml-mode
-  (:elpaca t)
+  (:pkg t)
   (:file-match (rx (or ".yml" ".yaml") eos)))
 
 (setup json-mode
-  (:elpaca t)
+  (:pkg t)
   (:file-match (rx ".json" eos)))
 
 (setup rustic
-  (:elpaca t)
+  (:pkg t)
   (:file-match (rx ".rs" eos))
   (:option rustic-format-on-save nil ; There's `format-all-mode'
            rustic-lsp-client archer-lsp-client))
 
 (setup terraform-mode
-  (:elpaca t)
+  (:pkg t)
   (:file-match (rx ".tf" eos)))
 
 (provide 'init-extra-modes)

--- a/home/mario/modules/editors/emacs/config/lisp/init-extra-modes.el
+++ b/home/mario/modules/editors/emacs/config/lisp/init-extra-modes.el
@@ -6,27 +6,34 @@
 
 ;;; Code:
 
-(setup-pkg cmake-mode
+(setup cmake-mode
+  (:elpaca t)
   (:file-match (rx (or "CmakeLists.txt" ".cmake") eos)))
 
-(setup-pkg nix-mode
+(setup nix-mode
+  (:elpaca t)
   (:file-match (rx ".nix" eos)))
 
-(setup-pkg markdown-mode
+(setup markdown-mode
+  (:elpaca t)
   (:file-match (rx (or ".md" ".markdown" ".mdown") eos)))
 
-(setup-pkg yaml-mode
+(setup yaml-mode
+  (:elpaca t)
   (:file-match (rx (or ".yml" ".yaml") eos)))
 
-(setup-pkg json-mode
+(setup json-mode
+  (:elpaca t)
   (:file-match (rx ".json" eos)))
 
-(setup-pkg rustic
+(setup rustic
+  (:elpaca t)
   (:file-match (rx ".rs" eos))
   (:option rustic-format-on-save nil ; There's `format-all-mode'
            rustic-lsp-client archer-lsp-client))
 
-(setup-pkg terraform-mode
+(setup terraform-mode
+  (:elpaca t)
   (:file-match (rx ".tf" eos)))
 
 (provide 'init-extra-modes)

--- a/home/mario/modules/editors/emacs/config/lisp/init-fonts.el
+++ b/home/mario/modules/editors/emacs/config/lisp/init-fonts.el
@@ -15,7 +15,8 @@
   :type 'integer
   :group 'archer-faces)
 
-(setup-pkg fontaine
+(setup fontaine
+  (:elpaca t)
   (:option x-underline-at-descent-line nil
            use-default-font-for-symbols t)
 

--- a/home/mario/modules/editors/emacs/config/lisp/init-fonts.el
+++ b/home/mario/modules/editors/emacs/config/lisp/init-fonts.el
@@ -16,7 +16,7 @@
   :group 'archer-faces)
 
 (setup fontaine
-  (:elpaca t)
+  (:pkg t)
   (:option x-underline-at-descent-line nil
            use-default-font-for-symbols t)
 

--- a/home/mario/modules/editors/emacs/config/lisp/init-help.el
+++ b/home/mario/modules/editors/emacs/config/lisp/init-help.el
@@ -7,14 +7,14 @@
 ;;; Code:
 
 (setup which-key
-  (:elpaca t)
+  (:pkg t)
   (:hide-mode)
   (:option which-key-idle-delay 0.2)
   (which-key-mode 1))
 
 (setup helpful
   (:disable t)
-  (:elpaca t)
+  (:pkg t)
   (:bind "C-h f"    helpful-callable
          "C-h v"    helpful-variable
          "C-h k"    helpful-key

--- a/home/mario/modules/editors/emacs/config/lisp/init-help.el
+++ b/home/mario/modules/editors/emacs/config/lisp/init-help.el
@@ -6,13 +6,15 @@
 
 ;;; Code:
 
-(setup-pkg which-key
+(setup which-key
+  (:elpaca t)
   (:hide-mode)
   (:option which-key-idle-delay 0.2)
   (which-key-mode 1))
 
-(setup-pkg helpful
-  :disabled
+(setup helpful
+  (:quit)
+  (:elpaca t)
   (:bind "C-h f"    helpful-callable
          "C-h v"    helpful-variable
          "C-h k"    helpful-key

--- a/home/mario/modules/editors/emacs/config/lisp/init-help.el
+++ b/home/mario/modules/editors/emacs/config/lisp/init-help.el
@@ -13,7 +13,7 @@
   (which-key-mode 1))
 
 (setup helpful
-  (:quit)
+  (:disable t)
   (:elpaca t)
   (:bind "C-h f"    helpful-callable
          "C-h v"    helpful-variable

--- a/home/mario/modules/editors/emacs/config/lisp/init-lsp.el
+++ b/home/mario/modules/editors/emacs/config/lisp/init-lsp.el
@@ -43,8 +43,9 @@
 ;;
 ;;; LSP-MODE
 
-(setup-pkg lsp-mode
-  :disabled
+(setup lsp-mode
+  (:quit)
+  (:elpaca t)
   (:autoload lsp)
 
   (:when-loaded
@@ -83,8 +84,9 @@
 
   (:hook-into lsp-enable-which-key-integration))
 
-(setup-pkg lsp-ui
-  :disabled
+(setup lsp-ui
+  (:quit)
+  (:elpaca t)
   (:autoload lsp-ui-mode)
   (:hook-into lsp-mode)
   (:load-after lsp)
@@ -96,8 +98,9 @@
              lsp-ui-sideline-show-code-actions t
              lsp-ui-sideline-delay 0.05)))
 
-(setup-pkg lsp-java
-  :disabled
+(setup lsp-java
+  (:quit)
+  (:elpaca t)
   (:load-after lsp))
 
 ;;
@@ -124,7 +127,8 @@
   (:with-mode (c-mode c++-mode java-mode nix-mode rustic-mode terraform-mode)
     (:hook eglot-ensure)))
 
-(setup-pkg eglot-java
+(setup eglot-java
+  (:elpaca t)
   (:load-after eglot)
   (:with-mode (java-mode)
     (:hook eglot-java-mode)))

--- a/home/mario/modules/editors/emacs/config/lisp/init-lsp.el
+++ b/home/mario/modules/editors/emacs/config/lisp/init-lsp.el
@@ -44,7 +44,7 @@
 ;;; LSP-MODE
 
 (setup lsp-mode
-  (:quit)
+  (:disable t)
   (:elpaca t)
   (:autoload lsp)
 
@@ -85,7 +85,7 @@
   (:hook-into lsp-enable-which-key-integration))
 
 (setup lsp-ui
-  (:quit)
+  (:disable t)
   (:elpaca t)
   (:autoload lsp-ui-mode)
   (:hook-into lsp-mode)
@@ -99,7 +99,7 @@
              lsp-ui-sideline-delay 0.05)))
 
 (setup lsp-java
-  (:quit)
+  (:disable t)
   (:elpaca t)
   (:load-after lsp))
 

--- a/home/mario/modules/editors/emacs/config/lisp/init-lsp.el
+++ b/home/mario/modules/editors/emacs/config/lisp/init-lsp.el
@@ -45,7 +45,7 @@
 
 (setup lsp-mode
   (:disable t)
-  (:elpaca t)
+  (:pkg t)
   (:autoload lsp)
 
   (:when-loaded
@@ -86,7 +86,7 @@
 
 (setup lsp-ui
   (:disable t)
-  (:elpaca t)
+  (:pkg t)
   (:autoload lsp-ui-mode)
   (:hook-into lsp-mode)
   (:load-after lsp)
@@ -100,7 +100,7 @@
 
 (setup lsp-java
   (:disable t)
-  (:elpaca t)
+  (:pkg t)
   (:load-after lsp))
 
 ;;
@@ -128,7 +128,7 @@
     (:hook eglot-ensure)))
 
 (setup eglot-java
-  (:elpaca t)
+  (:pkg t)
   (:load-after eglot)
   (:with-mode (java-mode)
     (:hook eglot-java-mode)))

--- a/home/mario/modules/editors/emacs/config/lisp/init-mail.el
+++ b/home/mario/modules/editors/emacs/config/lisp/init-mail.el
@@ -287,7 +287,8 @@ To improve."
     "D" archer-notmuch-show-delete-message
     "S" archer-notmuch-show-spam-message))
 
-(setup-pkg consult-notmuch
+(setup consult-notmuch
+  (:elpaca t)
   (:load-after consult notmuch))
 
 (setup sendmail

--- a/home/mario/modules/editors/emacs/config/lisp/init-mail.el
+++ b/home/mario/modules/editors/emacs/config/lisp/init-mail.el
@@ -288,7 +288,7 @@ To improve."
     "S" archer-notmuch-show-spam-message))
 
 (setup consult-notmuch
-  (:elpaca t)
+  (:pkg t)
   (:load-after consult notmuch))
 
 (setup sendmail

--- a/home/mario/modules/editors/emacs/config/lisp/init-media.el
+++ b/home/mario/modules/editors/emacs/config/lisp/init-media.el
@@ -7,10 +7,10 @@
 ;;; Code:
 
 (setup mpv
-  (:elpaca t))
+  (:pkg t))
 
 (setup emms
-  (:elpaca t)
+  (:pkg t)
   (:require emms-setup)
   (emms-all)
 

--- a/home/mario/modules/editors/emacs/config/lisp/init-media.el
+++ b/home/mario/modules/editors/emacs/config/lisp/init-media.el
@@ -6,9 +6,11 @@
 
 ;;; Code:
 
-(setup-pkg mpv)
+(setup mpv
+  (:elpaca t))
 
-(setup-pkg emms
+(setup emms
+  (:elpaca t)
   (:require emms-setup)
   (emms-all)
 

--- a/home/mario/modules/editors/emacs/config/lisp/init-meow.el
+++ b/home/mario/modules/editors/emacs/config/lisp/init-meow.el
@@ -7,7 +7,7 @@
 ;;; Code:
 
 (setup meow
-  (:elpaca t)
+  (:pkg t)
   (:require meow)
 
   (:hide-mode meow-normal)

--- a/home/mario/modules/editors/emacs/config/lisp/init-meow.el
+++ b/home/mario/modules/editors/emacs/config/lisp/init-meow.el
@@ -6,7 +6,8 @@
 
 ;;; Code:
 
-(setup-pkg meow
+(setup meow
+  (:elpaca t)
   (:require meow)
 
   (:hide-mode meow-normal)

--- a/home/mario/modules/editors/emacs/config/lisp/init-modeline.el
+++ b/home/mario/modules/editors/emacs/config/lisp/init-modeline.el
@@ -34,7 +34,7 @@
 
 ;; <https://github.com/minad/recursion-indicator>.
 (setup recursion-indicator
-  (:elpaca t)
+  (:pkg t)
   (:option recursion-indicator-general (concat "general" (all-the-icons-material "cached" :v-adjust -0.1))
            recursion-indicator-minibuffer (concat "minibuffer " (all-the-icons-material "cached" :v-adjust -0.1)))
 
@@ -49,7 +49,7 @@
 
 ;;; Keycast mode
 (setup keycast
-  (:elpaca t)
+  (:pkg t)
   ;; For `keycast-mode'
   (:option keycast-mode-line-window-predicate #'keycast-active-frame-bottom-right-p
            keycast-separator-width 1

--- a/home/mario/modules/editors/emacs/config/lisp/init-modeline.el
+++ b/home/mario/modules/editors/emacs/config/lisp/init-modeline.el
@@ -33,7 +33,8 @@
                   mode-line-misc-info)))
 
 ;; <https://github.com/minad/recursion-indicator>.
-(setup-pkg recursion-indicator
+(setup recursion-indicator
+  (:elpaca t)
   (:option recursion-indicator-general (concat "general" (all-the-icons-material "cached" :v-adjust -0.1))
            recursion-indicator-minibuffer (concat "minibuffer " (all-the-icons-material "cached" :v-adjust -0.1)))
 
@@ -47,7 +48,8 @@
   (recursion-indicator-mode 1))
 
 ;;; Keycast mode
-(setup-pkg keycast
+(setup keycast
+  (:elpaca t)
   ;; For `keycast-mode'
   (:option keycast-mode-line-window-predicate #'keycast-active-frame-bottom-right-p
            keycast-separator-width 1

--- a/home/mario/modules/editors/emacs/config/lisp/init-org-export.el
+++ b/home/mario/modules/editors/emacs/config/lisp/init-org-export.el
@@ -44,12 +44,14 @@
                                ("\\subparagraph{%s}" . "\\subparagraph*{%s}")))))
 
 ;; Reveal.js
-(setup-pkg (ox-reveal :host github :repo "yjwen/org-reveal")
+(setup ox-reveal
+  (:elpaca :host github :repo "yjwen/org-reveal")
   (:load-after ox)
   (:option org-reveal-root "https://cdn.jsdelivr.net/npm/reveal.js"))
 
 ;; Hugo
-(setup-pkg ox-hugo
+(setup ox-hugo
+  (:elpaca t)
   (:load-after ox))
 
 (provide 'init-org-export)

--- a/home/mario/modules/editors/emacs/config/lisp/init-org-export.el
+++ b/home/mario/modules/editors/emacs/config/lisp/init-org-export.el
@@ -45,13 +45,13 @@
 
 ;; Reveal.js
 (setup ox-reveal
-  (:elpaca (:host github :repo "yjwen/org-reveal"))
+  (:pkg (:host github :repo "yjwen/org-reveal"))
   (:load-after ox)
   (:option org-reveal-root "https://cdn.jsdelivr.net/npm/reveal.js"))
 
 ;; Hugo
 (setup ox-hugo
-  (:elpaca t)
+  (:pkg t)
   (:load-after ox))
 
 (provide 'init-org-export)

--- a/home/mario/modules/editors/emacs/config/lisp/init-org-export.el
+++ b/home/mario/modules/editors/emacs/config/lisp/init-org-export.el
@@ -45,7 +45,7 @@
 
 ;; Reveal.js
 (setup ox-reveal
-  (:elpaca :host github :repo "yjwen/org-reveal")
+  (:elpaca (:host github :repo "yjwen/org-reveal"))
   (:load-after ox)
   (:option org-reveal-root "https://cdn.jsdelivr.net/npm/reveal.js"))
 

--- a/home/mario/modules/editors/emacs/config/lisp/init-org.el
+++ b/home/mario/modules/editors/emacs/config/lisp/init-org.el
@@ -123,7 +123,7 @@
   (:hook archer-org-mode-setup))
 
 (setup org-appear
-  (:elpaca t)
+  (:pkg t)
   (:autoload org-appear-mode)
   (:hook-into org-mode)
   (:option org-appear-autoemphasis t
@@ -131,7 +131,7 @@
            org-appear-autosubmarkers t))
 
 (setup org-modern
-  (:elpaca t)
+  (:pkg t)
   (:load-after org)
   (:hook-into org-mode)
   (set-face-attribute 'org-modern-symbol nil :family "Iosevka Nerd Font")
@@ -145,11 +145,11 @@
            org-modern-table-horizontal 0))
 
 (setup org-modern-indent
-  (:elpaca (:host github :repo "jdtsmith/org-modern-indent"))
+  (:pkg (:host github :repo "jdtsmith/org-modern-indent"))
   (:hook-into org-indent-mode))
 
 (setup olivetti
-  (:elpaca t)
+  (:pkg t)
   (:load-after org)
   (:hook-into org-mode)
   (:option olivetti-body-width 0.75

--- a/home/mario/modules/editors/emacs/config/lisp/init-org.el
+++ b/home/mario/modules/editors/emacs/config/lisp/init-org.el
@@ -122,14 +122,16 @@
 
   (:hook archer-org-mode-setup))
 
-(setup-pkg org-appear
+(setup org-appear
+  (:elpaca t)
   (:autoload org-appear-mode)
   (:hook-into org-mode)
   (:option org-appear-autoemphasis t
            org-appear-autolinks nil
            org-appear-autosubmarkers t))
 
-(setup-pkg org-modern
+(setup org-modern
+  (:elpaca t)
   (:load-after org)
   (:hook-into org-mode)
   (set-face-attribute 'org-modern-symbol nil :family "Iosevka Nerd Font")
@@ -142,10 +144,12 @@
            org-modern-table-vertical 1
            org-modern-table-horizontal 0))
 
-(setup-pkg (org-modern-indent :host github :repo "jdtsmith/org-modern-indent")
+(setup org-modern-indent
+  (:elpaca :host github :repo "jdtsmith/org-modern-indent")
   (:hook-into org-indent-mode))
 
-(setup-pkg olivetti
+(setup olivetti
+  (:elpaca t)
   (:load-after org)
   (:hook-into org-mode)
   (:option olivetti-body-width 0.75

--- a/home/mario/modules/editors/emacs/config/lisp/init-org.el
+++ b/home/mario/modules/editors/emacs/config/lisp/init-org.el
@@ -145,7 +145,7 @@
            org-modern-table-horizontal 0))
 
 (setup org-modern-indent
-  (:elpaca :host github :repo "jdtsmith/org-modern-indent")
+  (:elpaca (:host github :repo "jdtsmith/org-modern-indent"))
   (:hook-into org-indent-mode))
 
 (setup olivetti

--- a/home/mario/modules/editors/emacs/config/lisp/init-pdf.el
+++ b/home/mario/modules/editors/emacs/config/lisp/init-pdf.el
@@ -20,7 +20,8 @@
   (:with-mode pdf-view-mode
     (:file-match "\\.[pP][dD][fF]\\'")))
 
-(setup-pkg saveplace-pdf-view
+(setup saveplace-pdf-view
+  (:elpaca t)
   (:load-after pdf-tools))
 
 (provide 'init-pdf)

--- a/home/mario/modules/editors/emacs/config/lisp/init-pdf.el
+++ b/home/mario/modules/editors/emacs/config/lisp/init-pdf.el
@@ -7,7 +7,7 @@
 ;;; Code:
 
 (setup pdf-tools
-  (:pkg (:nix t :post-install (pdf-tools-install :no-query)))
+  (:pkg (:built-in 'prefer :post-install (pdf-tools-install :no-query)))
   (:require pdf-tools)
 
   (:option display-buffer-alist '(("^\\*outline"

--- a/home/mario/modules/editors/emacs/config/lisp/init-pdf.el
+++ b/home/mario/modules/editors/emacs/config/lisp/init-pdf.el
@@ -7,9 +7,8 @@
 ;;; Code:
 
 (setup pdf-tools
-  (unless (archer-using-nix-p)
-    (elpaca pdf-tools
-      (pdf-tools-install :no-query)))
+  (:pkg (:nix t :post-install (pdf-tools-install :no-query)))
+  (:require pdf-tools)
 
   (:option display-buffer-alist '(("^\\*outline"
                                    display-buffer-in-side-window
@@ -20,8 +19,9 @@
   (:with-mode pdf-view-mode
     (:file-match "\\.[pP][dD][fF]\\'")))
 
+
 (setup saveplace-pdf-view
-  (:elpaca t)
+  (:pkg t)
   (:load-after pdf-tools))
 
 (provide 'init-pdf)

--- a/home/mario/modules/editors/emacs/config/lisp/init-performance.el
+++ b/home/mario/modules/editors/emacs/config/lisp/init-performance.el
@@ -7,7 +7,8 @@
 ;;; Code:
 
 
-(setup-pkg gcmh
+(setup gcmh
+  (:elpaca t)
   (:require)
   (:hide-mode)
   ;; The GC introduces annoying pauses and stuttering into our Emacs experience,

--- a/home/mario/modules/editors/emacs/config/lisp/init-performance.el
+++ b/home/mario/modules/editors/emacs/config/lisp/init-performance.el
@@ -8,7 +8,7 @@
 
 
 (setup gcmh
-  (:elpaca t)
+  (:pkg t)
   (:require)
   (:hide-mode)
   ;; The GC introduces annoying pauses and stuttering into our Emacs experience,

--- a/home/mario/modules/editors/emacs/config/lisp/init-projects.el
+++ b/home/mario/modules/editors/emacs/config/lisp/init-projects.el
@@ -7,7 +7,7 @@
 ;;; Code:
 
 (setup envrc
-  (:elpaca t)
+  (:pkg t)
   (:needs "direnv")
   (:with-hook after-init-hook
     (:hook envrc-global-mode)))
@@ -19,7 +19,7 @@
   (:option magit-display-buffer-function 'magit-display-buffer-same-window-except-diff-v1))
 
 ;; (setup forge
-;;   (:elpaca t)
+;;   (:pkg t)
 ;;   (:load-after magit))
 
 (setup ediff
@@ -28,12 +28,12 @@
            ediff-window-setup-function 'ediff-setup-windows-plain))
 
 (setup blamer
-  (:elpaca t))
+  (:pkg t))
 
 ;; `projectile', not using to try `project.el'
 (setup projectile
   (:disable t)
-  (:elpaca t)
+  (:pkg t)
   (:hide-mode)
 
   ;; NOTE: Set this to the folder where you keep your Git repos!
@@ -46,13 +46,13 @@
 
 (setup consult-projectile
   (:disable t)
-  (:elpaca t)
+  (:pkg t)
   (:load-after consult projectile))
 
 ;; `treemacs' stuff, I'm not using it
 (setup treemacs
   (:disable t)
-  (:elpaca t)
+  (:pkg t)
   (:option treemacs-deferred-git-apply-delay        0.5
            treemacs-directory-name-transformer      #'identity
            treemacs-display-in-side-window          t
@@ -134,18 +134,18 @@
 
 (setup treemacs-projectile
   (:disable t)
-  (:elpaca t)
+  (:pkg t)
   (:load-after treemacs projectile))
 
 (setup treemacs-all-the-icons
   (:disable t)
-  (:elpaca t)
+  (:pkg t)
   (:with-after treemacs
     (treemacs-load-theme "all-the-icons")))
 
 (setup treemacs-magit
   (:disable t)
-  (:elpaca t)
+  (:pkg t)
   (:load-after treemacs magit))
 
 (provide 'init-projects)

--- a/home/mario/modules/editors/emacs/config/lisp/init-projects.el
+++ b/home/mario/modules/editors/emacs/config/lisp/init-projects.el
@@ -6,7 +6,8 @@
 
 ;;; Code:
 
-(setup-pkg envrc
+(setup envrc
+  (:elpaca t)
   (:needs "direnv")
   (:with-hook after-init-hook
     (:hook envrc-global-mode)))
@@ -17,7 +18,8 @@
   (:autoload magit-status)
   (:option magit-display-buffer-function 'magit-display-buffer-same-window-except-diff-v1))
 
-;; (setup-pkg forge
+;; (setup forge
+;;   (:elpaca t)
 ;;   (:load-after magit))
 
 (setup ediff
@@ -25,11 +27,13 @@
   (:option ediff-split-window-function 'split-window-horizontally
            ediff-window-setup-function 'ediff-setup-windows-plain))
 
-(setup-pkg blamer)
+(setup blamer
+  (:elpaca t))
 
 ;; `projectile', not using to try `project.el'
-(setup-pkg projectile
-  :disabled
+(setup projectile
+  (:quit)
+  (:elpaca t)
   (:hide-mode)
 
   ;; NOTE: Set this to the folder where you keep your Git repos!
@@ -40,13 +44,15 @@
 
   (:global "C-c C-p" projectile-command-map))
 
-(setup-pkg consult-projectile
-  :disabled
+(setup consult-projectile
+  (:quit)
+  (:elpaca t)
   (:load-after consult projectile))
 
 ;; `treemacs' stuff, I'm not using it
-(setup-pkg treemacs
-  :disabled
+(setup treemacs
+  (:quit)
+  (:elpaca t)
   (:option treemacs-deferred-git-apply-delay        0.5
            treemacs-directory-name-transformer      #'identity
            treemacs-display-in-side-window          t
@@ -126,17 +132,20 @@
            "C-c C-t f"  treemacs-find-file
            "C-c C-t T"  treemacs-find-tag))
 
-(setup-pkg treemacs-projectile
-  :disabled
+(setup treemacs-projectile
+  (:quit)
+  (:elpaca t)
   (:load-after treemacs projectile))
 
-(setup-pkg treemacs-all-the-icons
-  :disabled
+(setup treemacs-all-the-icons
+  (:quit)
+  (:elpaca t)
   (:with-after treemacs
     (treemacs-load-theme "all-the-icons")))
 
-(setup-pkg treemacs-magit
-  :disabled
+(setup treemacs-magit
+  (:quit)
+  (:elpaca t)
   (:load-after treemacs magit))
 
 (provide 'init-projects)

--- a/home/mario/modules/editors/emacs/config/lisp/init-projects.el
+++ b/home/mario/modules/editors/emacs/config/lisp/init-projects.el
@@ -32,7 +32,7 @@
 
 ;; `projectile', not using to try `project.el'
 (setup projectile
-  (:quit)
+  (:disable t)
   (:elpaca t)
   (:hide-mode)
 
@@ -45,13 +45,13 @@
   (:global "C-c C-p" projectile-command-map))
 
 (setup consult-projectile
-  (:quit)
+  (:disable t)
   (:elpaca t)
   (:load-after consult projectile))
 
 ;; `treemacs' stuff, I'm not using it
 (setup treemacs
-  (:quit)
+  (:disable t)
   (:elpaca t)
   (:option treemacs-deferred-git-apply-delay        0.5
            treemacs-directory-name-transformer      #'identity
@@ -133,18 +133,18 @@
            "C-c C-t T"  treemacs-find-tag))
 
 (setup treemacs-projectile
-  (:quit)
+  (:disable t)
   (:elpaca t)
   (:load-after treemacs projectile))
 
 (setup treemacs-all-the-icons
-  (:quit)
+  (:disable t)
   (:elpaca t)
   (:with-after treemacs
     (treemacs-load-theme "all-the-icons")))
 
 (setup treemacs-magit
-  (:quit)
+  (:disable t)
   (:elpaca t)
   (:load-after treemacs magit))
 

--- a/home/mario/modules/editors/emacs/config/lisp/init-shell.el
+++ b/home/mario/modules/editors/emacs/config/lisp/init-shell.el
@@ -17,7 +17,8 @@
            vterm-max-scrollback 5000
            vterm-kill-buffer-on-exit t))
 
-(setup-pkg multi-vterm
+(setup multi-vterm
+  (:elpaca t)
   (:with-after vterm
     (:option multi-vterm-dedicated-window-height-percent 20)))
 

--- a/home/mario/modules/editors/emacs/config/lisp/init-shell.el
+++ b/home/mario/modules/editors/emacs/config/lisp/init-shell.el
@@ -7,7 +7,7 @@
 ;;; Code:
 
 (setup vterm
-  (:pkg (:nix t))
+  (:pkg (:built-in 'prefer))
 
   (:autoload vterm vterm-other-window)
 

--- a/home/mario/modules/editors/emacs/config/lisp/init-shell.el
+++ b/home/mario/modules/editors/emacs/config/lisp/init-shell.el
@@ -7,9 +7,7 @@
 ;;; Code:
 
 (setup vterm
-  (if (archer-using-nix-p)
-      (cl-pushnew 'vterm elpaca-ignored-dependencies)
-    (elpaca vterm))
+  (:pkg (:nix t))
 
   (:autoload vterm vterm-other-window)
 
@@ -18,7 +16,7 @@
            vterm-kill-buffer-on-exit t))
 
 (setup multi-vterm
-  (:elpaca t)
+  (:pkg t)
   (:with-after vterm
     (:option multi-vterm-dedicated-window-height-percent 20)))
 

--- a/home/mario/modules/editors/emacs/config/lisp/init-snippets.el
+++ b/home/mario/modules/editors/emacs/config/lisp/init-snippets.el
@@ -6,17 +6,20 @@
 
 ;;; Code:
 
-(setup-pkg yasnippet
+(setup yasnippet
+  (:elpaca t)
   (:with-mode yas-minor-mode
     (:hide-mode)
     (:hook-into prog-mode))
   (:when-loaded
     (yas-reload-all)))
 
-(setup-pkg yasnippet-snippets
+(setup yasnippet-snippets
+  (:elpaca t)
   (:load-after yasnippet))
 
-(setup-pkg yasnippet-capf
+(setup yasnippet-capf
+  (:elpaca t)
   (:load-after cape)
   (:global "C-c p y" cape-yasnippet))
 

--- a/home/mario/modules/editors/emacs/config/lisp/init-snippets.el
+++ b/home/mario/modules/editors/emacs/config/lisp/init-snippets.el
@@ -7,7 +7,7 @@
 ;;; Code:
 
 (setup yasnippet
-  (:elpaca t)
+  (:pkg t)
   (:with-mode yas-minor-mode
     (:hide-mode)
     (:hook-into prog-mode))
@@ -15,11 +15,11 @@
     (yas-reload-all)))
 
 (setup yasnippet-snippets
-  (:elpaca t)
+  (:pkg t)
   (:load-after yasnippet))
 
 (setup yasnippet-capf
-  (:elpaca t)
+  (:pkg t)
   (:load-after cape)
   (:global "C-c p y" cape-yasnippet))
 

--- a/home/mario/modules/editors/emacs/config/lisp/init-spell-and-check.el
+++ b/home/mario/modules/editors/emacs/config/lisp/init-spell-and-check.el
@@ -38,7 +38,8 @@
   (:hook-into prog-mode text-mode))
 
 ;; From Purcell
-(setup-pkg flymake-flycheck
+(setup flymake-flycheck
+  (:elpaca t)
   (:with-after flycheck
     (setq-default flycheck-disabled-checkers
                   (append (default-value 'flycheck-disabled-checkers)

--- a/home/mario/modules/editors/emacs/config/lisp/init-spell-and-check.el
+++ b/home/mario/modules/editors/emacs/config/lisp/init-spell-and-check.el
@@ -39,7 +39,7 @@
 
 ;; From Purcell
 (setup flymake-flycheck
-  (:elpaca t)
+  (:pkg t)
   (:with-after flycheck
     (setq-default flycheck-disabled-checkers
                   (append (default-value 'flycheck-disabled-checkers)

--- a/home/mario/modules/editors/emacs/config/lisp/init-telega.el
+++ b/home/mario/modules/editors/emacs/config/lisp/init-telega.el
@@ -9,7 +9,7 @@
 ;;; Code:
 
 (setup telega
-  (:pkg (:nix t))
+  (:pkg (:built-in 'prefer))
 
   (:autoload telega)
 

--- a/home/mario/modules/editors/emacs/config/lisp/init-telega.el
+++ b/home/mario/modules/editors/emacs/config/lisp/init-telega.el
@@ -9,9 +9,7 @@
 ;;; Code:
 
 (setup telega
-
-  (unless (archer-using-nix-p)
-    (elpaca telega))
+  (:pkg (:nix t))
 
   (:autoload telega)
 

--- a/home/mario/modules/editors/emacs/config/lisp/init-tex.el
+++ b/home/mario/modules/editors/emacs/config/lisp/init-tex.el
@@ -7,7 +7,8 @@
 
 ;;; Code:
 
-(setup-pkg auctex
+(setup auctex
+  (:elpaca t)
   (:with-mode LaTeX-mode
     (:file-match "\\.tex\\'"))
 

--- a/home/mario/modules/editors/emacs/config/lisp/init-tex.el
+++ b/home/mario/modules/editors/emacs/config/lisp/init-tex.el
@@ -8,7 +8,7 @@
 ;;; Code:
 
 (setup auctex
-  (:elpaca t)
+  (:pkg t)
   (:with-mode LaTeX-mode
     (:file-match "\\.tex\\'"))
 

--- a/home/mario/modules/editors/emacs/config/lisp/init-themes.el
+++ b/home/mario/modules/editors/emacs/config/lisp/init-themes.el
@@ -8,7 +8,7 @@
 
 
 (setup modus-themes
-  (:elpaca t)
+  (:pkg t)
   ;; Preferences
   (:option modus-themes-org-blocks 'gray-background
            modus-themes-mixed-fonts nil
@@ -84,11 +84,11 @@
   (modus-themes-select 'modus-operandi))
 
 (setup ef-themes
-  (:elpaca t))
+  (:pkg t))
 
 ;; I set circadian in the configuration of my themes
 (setup circadian
-  (:elpaca t)
+  (:pkg t)
   (:load-after modus-themes)
   (:option circadian-themes '(("8:00" . modus-operandi)
                               ("20:00" . modus-vivendi)))

--- a/home/mario/modules/editors/emacs/config/lisp/init-themes.el
+++ b/home/mario/modules/editors/emacs/config/lisp/init-themes.el
@@ -7,7 +7,8 @@
 ;;; Code:
 
 
-(setup-pkg modus-themes
+(setup modus-themes
+  (:elpaca t)
   ;; Preferences
   (:option modus-themes-org-blocks 'gray-background
            modus-themes-mixed-fonts nil
@@ -82,10 +83,12 @@
 
   (modus-themes-select 'modus-operandi))
 
-(setup-pkg ef-themes)
+(setup ef-themes
+  (:elpaca t))
 
 ;; I set circadian in the configuration of my themes
-(setup-pkg circadian
+(setup circadian
+  (:elpaca t)
   (:load-after modus-themes)
   (:option circadian-themes '(("8:00" . modus-operandi)
                               ("20:00" . modus-vivendi)))

--- a/home/mario/modules/editors/emacs/config/lisp/init-windows.el
+++ b/home/mario/modules/editors/emacs/config/lisp/init-windows.el
@@ -32,7 +32,7 @@
            "C-x }"      enlarge-window-horizontally))
 
 (setup beframe
-  (:elpaca t)
+  (:pkg t)
   (:option beframe-functions-in-frames '(project-prompt-project-dir)
            beframe-global-buffers '("*scratch*"
                                     "*Messages"
@@ -61,7 +61,7 @@
   (beframe-mode 1))
 
 (setup ace-window
-  (:elpaca t)
+  (:pkg t)
   (:global "M-o" ace-window
            "M-O" ace-swap-window)
   (:option aw-scope 'frame
@@ -69,7 +69,7 @@
            aw-minibuffer-flag t))
 
 (setup avy
-  (:elpaca t)
+  (:pkg t)
   (:global "M-g j" avy-goto-char-timer)
   (:option avy-all-windows nil   ;; only current
            avy-all-windows-alt t ;; all windows with C-u

--- a/home/mario/modules/editors/emacs/config/lisp/init-windows.el
+++ b/home/mario/modules/editors/emacs/config/lisp/init-windows.el
@@ -31,7 +31,8 @@
            "C-x {"      shrink-window-horizontally
            "C-x }"      enlarge-window-horizontally))
 
-(setup-pkg beframe
+(setup beframe
+  (:elpaca t)
   (:option beframe-functions-in-frames '(project-prompt-project-dir)
            beframe-global-buffers '("*scratch*"
                                     "*Messages"
@@ -59,14 +60,16 @@
 
   (beframe-mode 1))
 
-(setup-pkg ace-window
+(setup ace-window
+  (:elpaca t)
   (:global "M-o" ace-window
            "M-O" ace-swap-window)
   (:option aw-scope 'frame
            aw-dispatch-always t
            aw-minibuffer-flag t))
 
-(setup-pkg avy
+(setup avy
+  (:elpaca t)
   (:global "M-g j" avy-goto-char-timer)
   (:option avy-all-windows nil   ;; only current
            avy-all-windows-alt t ;; all windows with C-u


### PR DESCRIPTION
### Overview

Finally, integrate `setup.el` and `elpaca`, replacing the old custom macro approach with a bunch of useful keywords.

### Changes

#### Keyword `:pkg`
- Supports simple package names, recipe plists, and explicit package specifications.
- Automatically skips elpaca installation when using packages preferred as built-in, and adds packages to `elpaca-ignored-dependencies`.
- `:post-install` property runs setup code only after successful package installation.

#### Keyword `:disable`
- Conditionally disable entire setup forms based on runtime conditions. Right now the body gets wrapped with the condition

#### QoL
- **Setup modifiers management**: `+setup-add-modifier` allows to manage wrapper functions with positioning options (prepend, append, before, after).

### TODO

Before merging, respect the checklist:
- [x] Re-read the `wgrep` based refactor
- [x] Try this branch extensively on work machine
- [X] Check if code can be made a bit more readable and efficient