### PR TITLE
flake: bump before NixOS 25.11

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1755946532,
-        "narHash": "sha256-POePremlUY5GyA1zfbtic6XLxDaQcqHN6l+bIxdT5gc=",
+        "lastModified": 1762356719,
+        "narHash": "sha256-qwd/xdoOya1m8FENle+4hWnydCtlXUWLAW/Auk6WL7s=",
         "owner": "hyprwm",
         "repo": "aquamarine",
-        "rev": "81584dae2df6ac79f6b6dae0ecb7705e95129ada",
+        "rev": "6d0b3567584691bf9d8fedb5d0093309e2f979c7",
         "type": "github"
       },
       "original": {
@@ -71,11 +71,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1757430124,
-        "narHash": "sha256-MhDltfXesGH8VkGv3hmJ1QEKl1ChTIj9wmGAFfWj/Wk=",
+        "lastModified": 1763505477,
+        "narHash": "sha256-nJRd4LY2kT3OELfHqdgWjvToNZ4w+zKCMzS2R6z4sXE=",
         "owner": "lnl7",
         "repo": "nix-darwin",
-        "rev": "830b3f0b50045cf0bcfd4dab65fad05bf882e196",
+        "rev": "3bda9f6b14161becbd07b3c56411f1670e19b9b5",
         "type": "github"
       },
       "original": {
@@ -91,11 +91,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1757508292,
-        "narHash": "sha256-7lVWL5bC6xBIMWWDal41LlGAG+9u2zUorqo3QCUL4p4=",
+        "lastModified": 1762276996,
+        "narHash": "sha256-TtcPgPmp2f0FAnc+DMEw4ardEgv1SGNR3/WFGH0N19M=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "146f45bee02b8bd88812cfce6ffc0f933788875a",
+        "rev": "af087d076d3860760b3323f6b583f4d828c1ac17",
         "type": "github"
       },
       "original": {
@@ -186,11 +186,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1757784838,
-        "narHash": "sha256-6aHo1++bAFdW1z+0tfuxM9EmxHvon90mHo8/+izXMcY=",
+        "lastModified": 1763416652,
+        "narHash": "sha256-8EBEEvtzQ11LCxpQHMNEBQAGtQiCu/pqP9zSovDSbNM=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "6e28513cf2ee9a985c339fcef24d44f43d23456b",
+        "rev": "ea164b7c9ccdc2321379c2ff78fd4317b4c41312",
         "type": "github"
       },
       "original": {
@@ -244,11 +244,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1757542864,
-        "narHash": "sha256-8i9tsVoOmLQDHJkNgzJWnmxYFGkJNsSndimYpCoqmoA=",
+        "lastModified": 1762462052,
+        "narHash": "sha256-6roLYzcDf4V38RUMSqycsOwAnqfodL6BmhRkUtwIgdA=",
         "owner": "hyprwm",
         "repo": "hyprgraphics",
-        "rev": "aa9d14963b94186934fd0715d9a7f0f2719e64bb",
+        "rev": "ffc999d980c7b3bca85d3ebd0a9fbadf984a8162",
         "type": "github"
       },
       "original": {
@@ -262,8 +262,8 @@
         "aquamarine": "aquamarine",
         "hyprcursor": "hyprcursor",
         "hyprgraphics": "hyprgraphics",
+        "hyprland-guiutils": "hyprland-guiutils",
         "hyprland-protocols": "hyprland-protocols",
-        "hyprland-qtutils": "hyprland-qtutils",
         "hyprlang": "hyprlang",
         "hyprutils": "hyprutils",
         "hyprwayland-scanner": "hyprwayland-scanner",
@@ -273,16 +273,62 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1757774222,
-        "narHash": "sha256-U9+acA664xoegzxNDGA7xzvCW3Gplg1aq1TZurF2Ro0=",
+        "lastModified": 1763579307,
+        "narHash": "sha256-fGRiQjfwe6JMzizIffLD+YlNOk6YuM7Rxpexle64F1M=",
         "owner": "hyprwm",
         "repo": "Hyprland",
-        "rev": "16c18dde24450cce451f102fa09b8f7b60060306",
+        "rev": "7532115318cd5c1ddf434d93e37995e55d5bc8cb",
         "type": "github"
       },
       "original": {
         "owner": "hyprwm",
         "repo": "Hyprland",
+        "type": "github"
+      }
+    },
+    "hyprland-guiutils": {
+      "inputs": {
+        "aquamarine": [
+          "hyprland",
+          "aquamarine"
+        ],
+        "hyprgraphics": [
+          "hyprland",
+          "hyprgraphics"
+        ],
+        "hyprlang": [
+          "hyprland",
+          "hyprlang"
+        ],
+        "hyprtoolkit": "hyprtoolkit",
+        "hyprutils": [
+          "hyprland",
+          "hyprutils"
+        ],
+        "hyprwayland-scanner": [
+          "hyprland",
+          "hyprwayland-scanner"
+        ],
+        "nixpkgs": [
+          "hyprland",
+          "nixpkgs"
+        ],
+        "systems": [
+          "hyprland",
+          "systems"
+        ]
+      },
+      "locked": {
+        "lastModified": 1762755186,
+        "narHash": "sha256-ZjjETUHtoEhVN7JI1Cbt3p/KcXpK8ZQaPHx7UkG1OgA=",
+        "owner": "hyprwm",
+        "repo": "hyprland-guiutils",
+        "rev": "66356e20a8ed348aa49c1b9ceace786e224225b3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hyprwm",
+        "repo": "hyprland-guiutils",
         "type": "github"
       }
     },
@@ -298,84 +344,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1749046714,
-        "narHash": "sha256-kymV5FMnddYGI+UjwIw8ceDjdeg7ToDVjbHCvUlhn14=",
+        "lastModified": 1759610243,
+        "narHash": "sha256-+KEVnKBe8wz+a6dTLq8YDcF3UrhQElwsYJaVaHXJtoI=",
         "owner": "hyprwm",
         "repo": "hyprland-protocols",
-        "rev": "613878cb6f459c5e323aaafe1e6f388ac8a36330",
+        "rev": "bd153e76f751f150a09328dbdeb5e4fab9d23622",
         "type": "github"
       },
       "original": {
         "owner": "hyprwm",
         "repo": "hyprland-protocols",
-        "type": "github"
-      }
-    },
-    "hyprland-qt-support": {
-      "inputs": {
-        "hyprlang": [
-          "hyprland",
-          "hyprland-qtutils",
-          "hyprlang"
-        ],
-        "nixpkgs": [
-          "hyprland",
-          "hyprland-qtutils",
-          "nixpkgs"
-        ],
-        "systems": [
-          "hyprland",
-          "hyprland-qtutils",
-          "systems"
-        ]
-      },
-      "locked": {
-        "lastModified": 1749154592,
-        "narHash": "sha256-DO7z5CeT/ddSGDEnK9mAXm1qlGL47L3VAHLlLXoCjhE=",
-        "owner": "hyprwm",
-        "repo": "hyprland-qt-support",
-        "rev": "4c8053c3c888138a30c3a6c45c2e45f5484f2074",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hyprwm",
-        "repo": "hyprland-qt-support",
-        "type": "github"
-      }
-    },
-    "hyprland-qtutils": {
-      "inputs": {
-        "hyprland-qt-support": "hyprland-qt-support",
-        "hyprlang": [
-          "hyprland",
-          "hyprlang"
-        ],
-        "hyprutils": [
-          "hyprland",
-          "hyprland-qtutils",
-          "hyprlang",
-          "hyprutils"
-        ],
-        "nixpkgs": [
-          "hyprland",
-          "nixpkgs"
-        ],
-        "systems": [
-          "hyprland",
-          "systems"
-        ]
-      },
-      "locked": {
-        "lastModified": 1757508108,
-        "narHash": "sha256-bTYedtQFqqVBAh42scgX7+S3O6XKLnT6FTC6rpmyCCc=",
-        "owner": "hyprwm",
-        "repo": "hyprland-qtutils",
-        "rev": "119bcb9aa742658107b326c50dcd24ab59b309b7",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hyprwm",
-        "repo": "hyprland-qtutils",
         "type": "github"
       }
     },
@@ -395,16 +373,68 @@
         ]
       },
       "locked": {
-        "lastModified": 1756810301,
-        "narHash": "sha256-wgZ3VW4VVtjK5dr0EiK9zKdJ/SOqGIBXVG85C3LVxQA=",
+        "lastModified": 1763254292,
+        "narHash": "sha256-JNgz3Fz2KMzkT7aR72wsgu/xNeJB//LSmdilh8Z/Zao=",
         "owner": "hyprwm",
         "repo": "hyprlang",
-        "rev": "3d63fb4a42c819f198deabd18c0c2c1ded1de931",
+        "rev": "deea98d5b61d066bdc7a68163edd2c4bd28d3a6b",
         "type": "github"
       },
       "original": {
         "owner": "hyprwm",
         "repo": "hyprlang",
+        "type": "github"
+      }
+    },
+    "hyprtoolkit": {
+      "inputs": {
+        "aquamarine": [
+          "hyprland",
+          "hyprland-guiutils",
+          "aquamarine"
+        ],
+        "hyprgraphics": [
+          "hyprland",
+          "hyprland-guiutils",
+          "hyprgraphics"
+        ],
+        "hyprlang": [
+          "hyprland",
+          "hyprland-guiutils",
+          "hyprlang"
+        ],
+        "hyprutils": [
+          "hyprland",
+          "hyprland-guiutils",
+          "hyprutils"
+        ],
+        "hyprwayland-scanner": [
+          "hyprland",
+          "hyprland-guiutils",
+          "hyprwayland-scanner"
+        ],
+        "nixpkgs": [
+          "hyprland",
+          "hyprland-guiutils",
+          "nixpkgs"
+        ],
+        "systems": [
+          "hyprland",
+          "hyprland-guiutils",
+          "systems"
+        ]
+      },
+      "locked": {
+        "lastModified": 1762463729,
+        "narHash": "sha256-2fYkU/mdz8WKY3dkDPlE/j6hTxIwqultsx4gMMsMns0=",
+        "owner": "hyprwm",
+        "repo": "hyprtoolkit",
+        "rev": "88483bdee5329ec985f0c8f834c519cd18cfe532",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hyprwm",
+        "repo": "hyprtoolkit",
         "type": "github"
       }
     },
@@ -420,11 +450,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1756117388,
-        "narHash": "sha256-oRDel6pNl/T2tI+nc/USU9ZP9w08dxtl7hiZxa0C/Wc=",
+        "lastModified": 1763323331,
+        "narHash": "sha256-+Z0OfCo1MS8/aIutSAW5aJR9zTae1wz9kcJYMgpwN6M=",
         "owner": "hyprwm",
         "repo": "hyprutils",
-        "rev": "b2ae3204845f5f2f79b4703b441252d8ad2ecfd0",
+        "rev": "0c6411851cc779d551edc89b83966696201611aa",
         "type": "github"
       },
       "original": {
@@ -509,11 +539,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1757218147,
-        "narHash": "sha256-IwOwN70HvoBNB2ckaROxcaCvj5NudNc52taPsv5wtLk=",
+        "lastModified": 1763265660,
+        "narHash": "sha256-Ad9Rd3ZAidrH01xP73S3CjPiyXo7ywZs3uCESjPwUdc=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "9b144dc3ef6e42b888c4190e02746aab13b0e97f",
+        "rev": "469ef53571ea80890c9497952787920c79c1ee6e",
         "type": "github"
       },
       "original": {
@@ -524,11 +554,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1757487488,
-        "narHash": "sha256-zwE/e7CuPJUWKdvvTCB7iunV4E/+G0lKfv4kk/5Izdg=",
+        "lastModified": 1763283776,
+        "narHash": "sha256-Y7TDFPK4GlqrKrivOcsHG8xSGqQx3A6c+i7novT85Uk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ab0f3607a6c7486ea22229b92ed2d355f1482ee0",
+        "rev": "50a96edd8d0db6cc8db57dab6bb6d6ee1f3dc49a",
         "type": "github"
       },
       "original": {
@@ -540,11 +570,11 @@
     },
     "nixpkgs-darwin": {
       "locked": {
-        "lastModified": 1757746433,
-        "narHash": "sha256-fEvTiU4s9lWgW7mYEU/1QUPirgkn+odUBTaindgiziY=",
+        "lastModified": 1763464769,
+        "narHash": "sha256-AJHrsT7VoeQzErpBRlLJM1SODcaayp0joAoEA35yiwM=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "6d7ec06d6868ac6d94c371458fc2391ded9ff13d",
+        "rev": "6f374686605df381de8541c072038472a5ea2e2d",
         "type": "github"
       },
       "original": {
@@ -587,11 +617,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1757487488,
-        "narHash": "sha256-zwE/e7CuPJUWKdvvTCB7iunV4E/+G0lKfv4kk/5Izdg=",
+        "lastModified": 1763421233,
+        "narHash": "sha256-Stk9ZYRkGrnnpyJ4eqt9eQtdFWRRIvMxpNRf4sIegnw=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "ab0f3607a6c7486ea22229b92ed2d355f1482ee0",
+        "rev": "89c2b2330e733d6cdb5eae7b899326930c2c0648",
         "type": "github"
       },
       "original": {
@@ -603,11 +633,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1757034884,
-        "narHash": "sha256-PgLSZDBEWUHpfTRfFyklmiiLBE1i1aGCtz4eRA3POao=",
+        "lastModified": 1763191728,
+        "narHash": "sha256-esRhOS0APE6k40Hs/jjReXg+rx+J5LkWw7cuWFKlwYA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ca77296380960cd497a765102eeb1356eb80fed0",
+        "rev": "1d4c88323ac36805d09657d13a5273aea1b34f0c",
         "type": "github"
       },
       "original": {
@@ -627,11 +657,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1757588530,
-        "narHash": "sha256-tJ7A8mID3ct69n9WCvZ3PzIIl3rXTdptn/lZmqSS95U=",
+        "lastModified": 1763319842,
+        "narHash": "sha256-YG19IyrTdnVn0l3DvcUYm85u3PaqBt6tI6VvolcuHnA=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "b084b2c2b6bc23e83bbfe583b03664eb0b18c411",
+        "rev": "7275fa67fbbb75891c16d9dee7d88e58aea2d761",
         "type": "github"
       },
       "original": {
@@ -659,11 +689,11 @@
         "nixpkgs": "nixpkgs_4"
       },
       "locked": {
-        "lastModified": 1757503115,
-        "narHash": "sha256-S9F6bHUBh+CFEUalv/qxNImRapCxvSnOzWBUZgK1zDU=",
+        "lastModified": 1763509310,
+        "narHash": "sha256-s2WzTAD3vJtPACBCZXezNUMTG/wC6SFsU9DxazB9wDI=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "0bf793823386187dff101ee2a9d4ed26de8bbf8c",
+        "rev": "3ee33c0ed7c5aa61b4e10484d2ebdbdc98afb03e",
         "type": "github"
       },
       "original": {
@@ -748,11 +778,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1755354946,
-        "narHash": "sha256-zdov5f/GcoLQc9qYIS1dUTqtJMeDqmBmo59PAxze6e4=",
+        "lastModified": 1761431178,
+        "narHash": "sha256-xzjC1CV3+wpUQKNF+GnadnkeGUCJX+vgaWIZsnz9tzI=",
         "owner": "hyprwm",
         "repo": "xdg-desktop-portal-hyprland",
-        "rev": "a10726d6a8d0ef1a0c645378f983b6278c42eaa0",
+        "rev": "4b8801228ff958d028f588f0c2b911dbf32297f9",
         "type": "github"
       },
       "original": {

--- a/home/mario/modules/apps/rofi/default.nix
+++ b/home/mario/modules/apps/rofi/default.nix
@@ -10,27 +10,7 @@ with lib; let
   cfgWayland = config.mario.modules.wayland;
   cfgBitwarden = config.mario.modules.credentials.bitwarden;
 
-  rofiPkg =
-    if cfgWayland.enable
-    then pkgs.rofi-wayland
-    else pkgs.rofi;
-
   rofiFonts = pkgs.nerd-fonts.iosevka;
-
-  rofi-emoji =
-    if cfgWayland.enable
-    then pkgs.rofi-emoji-wayland
-    else pkgs.rofi-emoji;
-
-  rofi-powermenu =
-    if cfgWayland.enable
-    then pkgs.rofi-powermenu-wayland
-    else pkgs.rofi-powermenu;
-
-  rofi-rbw =
-    if cfgWayland.enable
-    then pkgs.rofi-rbw-wayland
-    else pkgs.rofi-rbw-x11;
 in {
   options.mario.modules.apps.rofi = {
     enable = mkEnableOption "rofi configuration";
@@ -39,13 +19,13 @@ in {
   config = mkIf cfg.enable {
     programs.rofi = {
       enable = true;
-      package = rofiPkg;
-      plugins = [rofi-emoji];
+      package = pkgs.rofi;
+      plugins = [pkgs.rofi-emoji];
     };
 
     home.packages = with pkgs;
-      [rofi-powermenu]
-      ++ optionals cfgBitwarden.enable [rofi-rbw]
+      [pkgs.rofi-powermenu]
+      ++ optionals cfgBitwarden.enable [pkgs.rofi-rbw]
       ++ [rofiFonts];
 
     xdg.configFile."rofi/colors/color.rasi".text = ''

--- a/home/mario/modules/browsers/firefox.nix
+++ b/home/mario/modules/browsers/firefox.nix
@@ -19,8 +19,6 @@ in {
       package =
         if pkgs.stdenv.isDarwin
         then null
-        else if cfgWayland.enable
-        then pkgs.firefox-wayland
         else pkgs.firefox;
 
       profiles.default = {

--- a/home/mario/modules/graphical/default.nix
+++ b/home/mario/modules/graphical/default.nix
@@ -18,7 +18,7 @@ with lib; let
     corefonts
     # Noto
     noto-fonts
-    noto-fonts-emoji
+    noto-fonts-color-emoji
     noto-fonts-cjk-sans
     # Icons
     font-awesome
@@ -29,7 +29,7 @@ with lib; let
     ibm-plex
   ];
 
-  social = with pkgs; [tdesktop];
+  social = with pkgs; [telegram-desktop];
 
   media = with pkgs; [
     pavucontrol
@@ -60,7 +60,7 @@ with lib; let
     ];
 
   desktop = with pkgs; [
-    transmission_3-gtk
+    transmission_4-gtk
   ];
 in {
   config = mkIf (cfgXorg.enable || cfgWayland.enable) {

--- a/home/mario/modules/shell/git.nix
+++ b/home/mario/modules/shell/git.nix
@@ -16,15 +16,15 @@ in {
   config = mkIf cfg.enable {
     programs.git = {
       enable = true;
-      userEmail = "mario.liguori.056@gmail.com";
-      userName = "archer-65";
+      settings.user.email = "mario.liguori.056@gmail.com";
+      settings.user.name = "archer-65";
 
       signing = {
         key = "BAC570B2172822A3";
         signByDefault = true;
       };
 
-      extraConfig = {
+      settings = {
         credential.helper = lib.mkIf cfgBw.enable "${pkgs.rbw}/bin/git-credential-rbw";
       };
 

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -14,8 +14,15 @@ in {
   # 'inputs.${flake}.legacyPackages.${pkgs.system}' or
   flake-inputs = final: _: {
     inputs =
-      builtins.mapAttrs
-      (_: flake: (flake.legacyPackages or flake.packages or {}).${final.system} or {})
+      builtins.mapAttrs (
+        _: flake: let
+          legacyPackages = (flake.legacyPackages or {}).${final.stdenv.hostPlatform.system} or {};
+          packages = (flake.packages or {}).${final.stdenv.hostPlatform.system} or {};
+        in
+          if legacyPackages != {}
+          then legacyPackages
+          else packages
+      )
       inputs;
   };
 
@@ -42,18 +49,6 @@ in {
           url = "https://github.com/terraform-docs/terraform-docs/pull/872.patch";
           sha256 = "664ZtL/fqJSpmTSISEqYyRnNIvXjoSripCJUPxMKy+I=";
         })
-      ];
-    });
-
-    rofi-emoji-wayland = prev.rofi-emoji.overrideAttrs (oldAttrs: rec {
-      buildInputs = with final; [
-        rofi-wayland-unwrapped
-        cairo
-        glib
-        libnotify
-        wl-clipboard
-        xclip
-        xsel
       ];
     });
 

--- a/packages/rofi-powermenu/default.nix
+++ b/packages/rofi-powermenu/default.nix
@@ -4,17 +4,11 @@
   stdenv,
   makeWrapper,
   procps,
-  # wayland-only deps
-  rofi-wayland,
-  # x11-only deps
   rofi,
-  # backend selector
-  backend ? "x11",
 }:
 with lib; let
   name = "rofi-powermenu";
 in
-  assert lib.assertOneOf "backend" backend ["x11" "wayland"];
     stdenv.mkDerivation {
       inherit name;
       version = "1.0";
@@ -30,15 +24,10 @@ in
         install -Dm 0755 $src $out/bin/${name}
         wrapProgram $out/bin/${name} --prefix PATH ':' \
           "${
-          makeBinPath ([
+          makeBinPath [
               procps
-            ]
-            ++ lib.optionals (backend == "x11") [
               rofi
-            ]
-            ++ lib.optionals (backend == "wayland") [
-              rofi-wayland
-            ])
+          ]
         }"
       '';
 

--- a/system/hosts/macbook/default.nix
+++ b/system/hosts/macbook/default.nix
@@ -10,7 +10,7 @@
 
     casks = [
       "firefox"
-      "docker"
+      "docker-desktop"
       "microsoft-teams"
       "microsoft-excel"
       "tunnelblick"

--- a/system/hosts/mate/default.nix
+++ b/system/hosts/mate/default.nix
@@ -6,6 +6,7 @@
   imports = [./hardware-configuration.nix ./options.nix];
 
   # Kernel related
+  hardware.amdgpu.initrd.enable = true;
 
   boot.kernelPackages = pkgs.linuxPackages_latest;
   boot.initrd.kernelModules = ["amdgpu"];
@@ -31,7 +32,7 @@
   hardware.graphics = {
     enable = true;
     enable32Bit = true;
-    extraPackages = with pkgs; [amdvlk vaapiVdpau libvdpau-va-gl];
+    extraPackages = with pkgs; [libva-vdpau-driver libvdpau-va-gl];
   };
 
   services.xserver = {

--- a/system/hosts/quietfrost/default.nix
+++ b/system/hosts/quietfrost/default.nix
@@ -6,8 +6,9 @@
   imports = [./hardware-configuration.nix ./options.nix];
 
   # Kernel related
+  hardware.amdgpu.initrd.enable = true;
+
   boot.kernelPackages = pkgs.linuxPackages_latest;
-  boot.kernelModules = ["amdgpu"];
   boot.kernelParams = [
     "initcall_blacklist=acpi_cpufreq_init"
     "amd_pstate=active"
@@ -43,7 +44,7 @@
   hardware.graphics = {
     enable = true;
     enable32Bit = true;
-    extraPackages = with pkgs; [amdvlk vaapiVdpau libvdpau-va-gl];
+    extraPackages = with pkgs; [libva-vdpau-driver libvdpau-va-gl];
   };
 
   services.xserver = {

--- a/system/hosts/quietfrost/options.nix
+++ b/system/hosts/quietfrost/options.nix
@@ -51,8 +51,9 @@
   primaryUser.shell = pkgs.zsh;
 
   services.flatpak.enable = true;
+
   # TODO: Move this away
-  hardware.graphics.extraPackages = with pkgs; [rocmPackages.clr.icd];
+  hardware.amdgpu.opencl.enable = true;
   systemd.tmpfiles.rules = let
     rocmEnv = pkgs.symlinkJoin {
       name = "rocm-combined";

--- a/system/modules/dev/virt-manager.nix
+++ b/system/modules/dev/virt-manager.nix
@@ -17,10 +17,6 @@ in {
       enable = true;
       qemu = {
         package = pkgs.qemu_kvm;
-        ovmf = {
-          enable = true;
-          packages = [pkgs.OVMFFull];
-        };
         swtpm.enable = true;
       };
     };

--- a/system/modules/graphical/greetd.nix
+++ b/system/modules/graphical/greetd.nix
@@ -45,7 +45,7 @@ in {
       settings = {
         default_session = {
           # command = "${config.programs.sway.package}/bin/sway --config ${greetd-sway-config}";
-          command = "${pkgs.greetd.tuigreet}/bin/tuigreet --time --remember";
+          command = "${pkgs.tuigreet}/bin/tuigreet --time --remember";
           user = "greeter";
         };
       };


### PR DESCRIPTION
## Changes

### NixOS and HM

* Remove OVMF deprecated options
* Use AMDGPU hardware modules where possible
* Use `stdenv.hostPlatform.system` where possible
* Remove `rofi-.*-wayland` versions of packages, and dirty hacks living this repo since 2022
* Remove also other deprecated packages

### Darwin

* Rename `docker` cask to `docker-desktop`