### PR TITLE
emacs: bump packages and refactor config accordingly

### DIFF
--- a/home/mario/modules/editors/emacs/config/lisp/init-buffers.el
+++ b/home/mario/modules/editors/emacs/config/lisp/init-buffers.el
@@ -14,7 +14,7 @@
      :header-mouse-map ibuffer-size-header-map)
     (file-size-human-readable (buffer-size)))
   ;; Modify the default ibuffer-formats
-  (:option ibuffer-formats
+  (setopt ibuffer-formats
            '((mark modified read-only locked " "
                    (name 20 20 :left :elide)
                    " "
@@ -27,7 +27,7 @@
                    (name 16 -1)
                    " " filename)))
   ;; Add groups
-  (:option ibuffer-saved-filter-groups
+  (setopt ibuffer-saved-filter-groups
            '(("default"
               ("dired" (mode . dired-mode))
               ("git"   (or (mode . magit-mode)
@@ -56,7 +56,7 @@
                         (name . "^\\*straight-process\\*$")
                         (name . "^\\*dashboard\\*$"))))))
 
-  (:option ibuffer-expert t
+  (setopt ibuffer-expert t
            ibuffer-display-summary t
            ibuffer-show-empty-filter-groups nil
            ibuffer-use-other-window nil
@@ -68,11 +68,11 @@
   (:hook (lambda () (ibuffer-switch-to-saved-filter-groups "default")
            (ibuffer-auto-mode 1)))
 
-  (:global "C-x C-b" ibuffer))
+  (keymap-global-set "C-x C-b" 'ibuffer))
 
 ;;; Unique names for buffers
 (setup (:require uniquify)
-  (:option uniquify-buffer-name-style 'forward
+  (setopt uniquify-buffer-name-style 'forward
            uniquify-strip-common-suffix t
            uniquify-after-kill-buffer-p t))
 

--- a/home/mario/modules/editors/emacs/config/lisp/init-code-style.el
+++ b/home/mario/modules/editors/emacs/config/lisp/init-code-style.el
@@ -11,7 +11,7 @@
   (:pkg t)
   (:hide-mode)
   (:hook-into prog-mode)
-  (:global "<f1>" format-all-buffer))
+  (keymap-global-set "<f1>" 'format-all-buffer))
 
 (setup editorconfig
   (:pkg t)
@@ -30,12 +30,12 @@
   (:pkg t)
   (:require)
   (:hook-into prog-mode)
-  (:option mode-require-final-newline t
+  (setopt mode-require-final-newline t
            require-final-newline t))
 
 ;; Tabs, indentation, and the TAB key
 (setup indent
-  (:option tab-always-indent 'complete
+  (setopt tab-always-indent 'complete
            tab-first-completion 'word-or-paren-or-punct
            tab-width 2
            indent-tabs-mode nil)) ; Use spaces!
@@ -49,14 +49,14 @@
 
     (progn
       (setup treesit
-        (:option treesit-font-lock-level 4))
+        (setopt treesit-font-lock-level 4))
 
       (setup treesit-auto
         (:pkg t)
         (:load-after treesit)
         (:autoload global-treesit-auto-mode)
 
-        (:option treesit-auto-install 'prompt)
+        (setopt treesit-auto-install 'prompt)
         (global-treesit-auto-mode)))
 
   (progn

--- a/home/mario/modules/editors/emacs/config/lisp/init-complete-in-buffer.el
+++ b/home/mario/modules/editors/emacs/config/lisp/init-complete-in-buffer.el
@@ -9,7 +9,7 @@
 (setup corfu
   (:pkg (:files (:defaults "extensions/*")
                    :includes (corfu-history corfu-popupinfo corfu-info)))
-  (:option corfu-cycle t
+  (setopt corfu-cycle t
            corfu-auto t
            corfu-auto-delay 0.3
            corfu-auto-prefix 3
@@ -87,7 +87,7 @@ Useful for prompts such as `eval-expression' and `shell-command'."
 (setup corfu-popupinfo
   (:autoload corfu-popupinfo-mode)
   (:with-after corfu
-    (:option corfu-popupinfo-delay '(0.5 . 0))
+    (setopt corfu-popupinfo-delay '(0.5 . 0))
     (corfu-popupinfo-mode 1)
     (:with-map corfu-popupinfo-map
       (:bind
@@ -105,7 +105,7 @@ Useful for prompts such as `eval-expression' and `shell-command'."
 (setup kind-icon
   (:pkg t)
   (:with-after corfu
-    (:option kind-icon-default-face 'corfu-default
+    (setopt kind-icon-default-face 'corfu-default
              kind-icon-default-style '(:padding 0 :stroke 0 :margin 0 :radius 0 :height 0.7 :scale 1.0))
     (add-to-list 'corfu-margin-formatters #'kind-icon-margin-formatter)))
 
@@ -119,24 +119,24 @@ Useful for prompts such as `eval-expression' and `shell-command'."
   (dolist (backend '(cape-elisp-symbol cape-keyword cape-file cape-history cape-dabbrev))
     (add-to-list 'completion-at-point-functions backend))
 
-  (:global "C-c p p"  completion-at-point
-           "C-c p t"  complete-tag
-           "C-c p d"  cape-dabbrev
-           "C-c p h"  cape-history
-           "C-c p f"  cape-file
-           "C-c p k"  cape-keyword
-           "C-c p s"  cape-elisp-symbol
-           "C-c p e"  cape-elisp-block
-           "C-c p a"  cape-abbrev
-           "C-c p i"  cape-ispell
-           "C-c p l"  cape-line
-           "C-c p w"  cape-dict
-           "C-c p :"  cape-emoji
-           "C-c p \\" cape-tex
-           "C-c p _"  cape-tex
-           "C-c p ^"  cape-tex
-           "C-c p &"  cape-sgml
-           "C-c p r"  cape-rfc1345))
+  (keymap-global-set "C-c p p"  'completion-at-point)
+  (keymap-global-set "C-c p t"  'complete-tag)
+  (keymap-global-set "C-c p d"  'cape-dabbrev)
+  (keymap-global-set "C-c p h"  'cape-history)
+  (keymap-global-set "C-c p f"  'cape-file)
+  (keymap-global-set "C-c p k"  'cape-keyword)
+  (keymap-global-set "C-c p s"  'cape-elisp-symbol)
+  (keymap-global-set "C-c p e"  'cape-elisp-block)
+  (keymap-global-set "C-c p a"  'cape-abbrev)
+  (keymap-global-set "C-c p i"  'cape-ispell)
+  (keymap-global-set "C-c p l"  'cape-line)
+  (keymap-global-set "C-c p w"  'cape-dict)
+  (keymap-global-set "C-c p :"  'cape-emoji)
+  (keymap-global-set "C-c p \\" 'cape-tex)
+  (keymap-global-set "C-c p _"  'cape-tex)
+  (keymap-global-set "C-c p ^"  'cape-tex)
+  (keymap-global-set "C-c p &"  'cape-sgml)
+  (keymap-global-set "C-c p r"  'cape-rfc1345))
 
 (provide 'init-complete-in-buffer)
 ;;; init-complete-in-buffer.el ends here

--- a/home/mario/modules/editors/emacs/config/lisp/init-complete.el
+++ b/home/mario/modules/editors/emacs/config/lisp/init-complete.el
@@ -64,7 +64,7 @@
               vertico-multiform
               vertico-unobtrusive)
 
-  (:option vertico-scroll-margin 0
+  (setopt vertico-scroll-margin 0
            vertico-count 12
            vertico-resize t
            vertico-cycle t)
@@ -88,10 +88,10 @@
     (nconc (seq-filter (lambda (x) (string-suffix-p "/" x)) files)
            (seq-remove (lambda (x) (string-suffix-p "/" x)) files)))
 
-  (:option vertico-multiform-commands
+  (setopt vertico-multiform-commands
            '((dired (vertico-sort-function . sort-directories-first))))
 
-  (:option vertico-multiform-categories
+  (setopt vertico-multiform-categories
            '(
              ;; (consult-grep buffer)
              ;; (consult-ripgrep buffer)
@@ -169,17 +169,17 @@
      ((string-suffix-p "~" pattern)
       (cons 'orderless-flex (substring pattern 0 -1)))))
 
-  (:option completion-styles '(orderless basic)
+  (setopt completion-styles '(orderless basic)
            orderless-component-separator 'orderless-escapable-split-on-space
            completion-category-defaults nil)
 
-  (:option orderless-style-dispatchers
+  (setopt orderless-style-dispatchers
            '(archer-orderless-literal-dispatcher
              archer-orderless-without-literal-dispatcher
              archer-orderless-initialism-dispatcher
              archer-orderless-flex-dispatcher))
 
-  (:option completion-category-overrides
+  (setopt completion-category-overrides
            '((file (styles . (partial-completion basic orderless)))
              (project-file (styles . (partial-completion basic orderless))))))
 

--- a/home/mario/modules/editors/emacs/config/lisp/init-consult.el
+++ b/home/mario/modules/editors/emacs/config/lisp/init-consult.el
@@ -11,25 +11,25 @@
   (:require consult)
 
   ;; C-c bindings (mode specific)
-  (:global "C-c h" consult-history
-           "C-c M" consult-mode-command
-           "C-c b" consult-bookmark
-           "C-c k" consult-kmacro)
+  (keymap-global-set "C-c h" 'consult-history)
+  (keymap-global-set "C-c M" 'consult-mode-command)
+  (keymap-global-set "C-c b" 'consult-bookmark)
+  (keymap-global-set "C-c k" 'consult-kmacro)
 
   ;; C-x bindings
-  (:global "C-x M-c" consult-complex-command      ; orig. repeat-complex-command
-           "C-x b"   consult-buffer               ; orig. switch-to-buffer
-           "C-x 4 b" consult-buffer-other-window  ; orig. switch-to-buffer-other-window
-           "C-x 5 b" consult-buffer-other-frame)  ; orig. switch-to-buffer-other-frame
+  (keymap-global-set "C-x M-c" 'consult-complex-command)      ; orig. repeat-complex-command
+  (keymap-global-set "C-x b"   'consult-buffer)               ; orig. switch-to-buffer
+  (keymap-global-set "C-x 4 b" 'consult-buffer-other-window)  ; orig. switch-to-buffer-other-window
+  (keymap-global-set "C-x 5 b" 'consult-buffer-other-frame)   ; orig. switch-to-buffer-other-frame
 
   ;; [C]-[M]-# bindings for registers
-  (:global "C-M-#" consult-register
-           "M-#"   consult-register-load
-           "C-#"   consult-register-store) ; orig. abbrev-prefix-mark (unrelated)
+  (keymap-global-set "C-M-#" 'consult-register)
+  (keymap-global-set "M-#"   'consult-register-load)
+  (keymap-global-set "C-#"   'consult-register-store) ; orig. abbrev-prefix-mark (unrelated)
 
   ;; Other custom bindings
-  (:global "M-y"   consult-yank-pop  ; orig. yank-po
-           "C-h a" consult-apropos)  ; orig. apropos-comman
+  (keymap-global-set "M-y"   'consult-yank-pop) ; orig. yank-po
+  (keymap-global-set "C-h a" 'consult-apropos)  ; orig. apropos-comman
 
   ;; M-g bindings (goto-map)
   (:with-map goto-map
@@ -69,14 +69,14 @@
   ;; Register formatting. This improves the register
   ;; preview for `consult-register', `consult-register-load',
   ;; `consult-register-store' and the Emacs built-ins.
-  (:option register-preview-delay 0
+  (setopt register-preview-delay 0
            register-preview-function #'consult-register-format)
 
   ;; Optionally configure the narrowing key.
-  (:option consult-narrow-key "<")
+  (setopt consult-narrow-key "<")
 
   ;; Use Consult to select xref locations with preview
-  (:option xref-show-xrefs-function #'consult-xref
+  (setopt xref-show-xrefs-function #'consult-xref
            xref-show-definitions-function #'consult-xref)
 
   ;; Optionally configure preview. The default value
@@ -115,7 +115,7 @@
 (setup consult-dir
   (:pkg t)
   (:with-after consult
-    (:global "C-x C-d" consult-dir)
+    (keymap-global-set "C-x C-d" 'consult-dir)
     (:with-map minibuffer-local-completion-map
       (:bind
        "C-x C-d" consult-dir-maybe
@@ -124,7 +124,7 @@
 (setup consult-eglot
   (:pkg t)
   (:with-after (consult eglot)
-    (:global "M-g s" consult-eglot-symbols)))
+    (keymap-global-set "M-g s" 'consult-eglot-symbols)))
 
 (provide 'init-consult)
 ;;; init-consult.el ends here

--- a/home/mario/modules/editors/emacs/config/lisp/init-dash.el
+++ b/home/mario/modules/editors/emacs/config/lisp/init-dash.el
@@ -8,7 +8,7 @@
 
 (setup dashboard
   (:pkg t)
-  (:option dashboard-banner-logo-title "SUCK(EMAC)S - Personal Workspace"
+  (setopt dashboard-banner-logo-title "SUCK(EMAC)S - Personal Workspace"
            dashboard-startup-banner (expand-file-name "img/stallman.png" user-emacs-directory)
            dashboard-center-content t
            ;; Icons

--- a/home/mario/modules/editors/emacs/config/lisp/init-dired.el
+++ b/home/mario/modules/editors/emacs/config/lisp/init-dired.el
@@ -22,7 +22,7 @@
             dired-make-directory-clickable t
             dired-free-space nil))
 
-  (:option dired-listing-switches "-agho --group-directories-first"
+  (setopt dired-listing-switches "-agho --group-directories-first"
            dired-kill-when-opening-new-dired-buffer t
            dired-recursive-copies 'always
            dired-recursive-deletes 'always
@@ -38,7 +38,7 @@
     (:bind "M-<return>" archer-dired-open-file)))
 
 (setup (:require dired-x)
-  (:option dired-clean-confirm-killing-deleted-buffers t
+  (setopt dired-clean-confirm-killing-deleted-buffers t
            dired-clean-up-buffers-too t
            dired-x-hands-off-my-keys t
            dired-omit-files "^\\.$\\|^\\.[^.]")
@@ -53,17 +53,17 @@
     (:hook dired-omit-mode)))
 
 (setup (:require dired-aux)
-  (:option dired-create-destination-dirs 'always
+  (setopt dired-create-destination-dirs 'always
            dired-do-revert-buffer t
            dired-isearch-filenames 'dwim
            dired-vc-rename-file t))
 
 (setup (:require wdired)
-  (:option wdired-allow-to-change-permissions t
+  (setopt wdired-allow-to-change-permissions t
            wdired-create-parent-directories t))
 
 (setup (:require image-dired)
-  (:option image-dired-external-viewer "xdg-open"
+  (setopt image-dired-external-viewer "xdg-open"
            image-dired-thumb-size 80
            image-dired-thumb-margin 2
            image-dired-thumb-relief 0
@@ -80,7 +80,7 @@
 (setup dired-subtree
   (:pkg t)
   (:load-after dired)
-  (:option dired-subtree-use-backgrounds nil)
+  (setopt dired-subtree-use-backgrounds nil)
   (:with-map dired-mode-map
     (:bind
       "<tab>" dired-subtree-toggle
@@ -89,7 +89,7 @@
 (setup dired-sidebar
   (:pkg t)
   (:load-after dired)
-  (:global "C-x C-n" dired-sidebar-toggle-sidebar))
+  (keymap-global-set "C-x C-n" 'dired-sidebar-toggle-sidebar))
 
 (setup dired-collapse
   (:pkg t)
@@ -98,13 +98,13 @@
 
 (setup all-the-icons-dired
   (:pkg t)
-  (:option all-the-icons-dired-monochrome nil)
+  (setopt all-the-icons-dired-monochrome nil)
   (:with-after (all-the-icons dired)
     (:hook-into dired-mode-hook)))
 
 (setup trashed
   (:pkg t)
-  (:option trashed-action-confirmer 'y-or-n-p
+  (setopt trashed-action-confirmer 'y-or-n-p
            trashed-use-header-line t
            trashed-sort-key '("Date deleted" . t)))
 

--- a/home/mario/modules/editors/emacs/config/lisp/init-editing.el
+++ b/home/mario/modules/editors/emacs/config/lisp/init-editing.el
@@ -35,15 +35,15 @@
   (:pkg t)
   ;; The package doesn't set this by default so we must place
   ;; auto save files in the same path as it uses for sessions
-  (:option auto-save-file-name-transforms `((".*" ,(no-littering-expand-var-file-name "auto-save/")))))
+  (setopt auto-save-file-name-transforms `((".*" ,(no-littering-expand-var-file-name "auto-save/") t))))
 
 (setup saveplace
-  (:option save-place-file (expand-file-name "var/saveplace" user-emacs-directory))
+  (setopt save-place-file (expand-file-name "var/saveplace" user-emacs-directory))
   (setq save-place-forget-unreadable-files t)
   (save-place-mode 1))
 
 (setup backup
-  (:option backup-directory-alist `(("." . ,(expand-file-name "var/backup" user-emacs-directory))))
+  (setopt backup-directory-alist `(("." . ,(expand-file-name "var/backup" user-emacs-directory))))
   (setq backup-by-copying t)
   (setq version-control t)
   (setq delete-old-versions t)
@@ -60,7 +60,7 @@
   (setq-default display-line-numbers-width 3)
 
   ;; Preferences
-  (:option display-line-numbers-type 'relative
+  (setopt display-line-numbers-type 'relative
            display-line-numbers-width-start nil
            display-line-numbers-grow-only t)
 
@@ -112,7 +112,7 @@
 
 (setup ultra-scroll
   (:pkg (:host github :repo "jdtsmith/ultra-scroll"))
-  (:option scroll-conservatively 101
+  (setopt scroll-conservatively 101
            scroll-margin 0)
   (:when-loaded
     (ultra-scroll-mode 1)))
@@ -133,19 +133,19 @@
   (setq mouse-1-click-follows-link t)
   (setq mouse-yank-at-point t)
 
-  (:global "<mouse-2>" clipboard-yank))
+  (keymap-global-set "<mouse-2>" 'clipboard-yank))
 
 (setup elec-pair
   (electric-pair-mode 1))
 
 (setup paren
-  (:option show-paren-style 'parenthesis
+  (setopt show-paren-style 'parenthesis
            show-paren-when-point-in-periphery t
            show-paren-when-point-inside-paren nil)
   (show-paren-mode 1))
 
 (setup selection
-  (:option save-interprogram-paste-before-kill t
+  (setopt save-interprogram-paste-before-kill t
            kill-do-not-save-duplicates t
            kill-whole-line t
            select-enable-clipboard t
@@ -164,11 +164,11 @@
 
 (setup goto-last-change
   (:pkg t)
-  (:global "C-z" goto-last-change))
+  (keymap-global-set "C-z" 'goto-last-change))
 
 (setup (:require autorevert)
   (:hide-mode auto-revert)
-  (:option auto-revert-verbose t
+  (setopt auto-revert-verbose t
            global-auto-revert-non-file-buffers t)
   (:with-hook after-init-hook
     (:hook global-auto-revert-mode)))

--- a/home/mario/modules/editors/emacs/config/lisp/init-embark.el
+++ b/home/mario/modules/editors/emacs/config/lisp/init-embark.el
@@ -52,9 +52,9 @@ targets."
     (setq prefix-help-command #'embark-prefix-help-command)
     (advice-add #'embark-completing-read-prompter :around #'archer-embark-hide-which-key-indicator))
 
-  (:global "C-." embark-act
-           "C-;" embark-dwim
-           "C-h B" embark-bindings) ;; alternative for `describe-bindings'
+  (keymap-global-set "C-."   'embark-act)
+  (keymap-global-set "C-;"   'embark-dwim)
+  (keymap-global-set "C-h B" 'embark-bindings) ;; alternative for `describe-bindings'
 
   ;; Hide the mode line of the Embark live/completions buffers
   (add-to-list 'display-buffer-alist

--- a/home/mario/modules/editors/emacs/config/lisp/init-extra-modes.el
+++ b/home/mario/modules/editors/emacs/config/lisp/init-extra-modes.el
@@ -8,33 +8,33 @@
 
 (setup cmake-mode
   (:pkg t)
-  (:file-match (rx (or "CmakeLists.txt" ".cmake") eos)))
+  (:match-file (rx (or "CmakeLists.txt" ".cmake") eos)))
 
 (setup nix-mode
   (:pkg t)
-  (:file-match (rx ".nix" eos)))
+  (:match-file (rx ".nix" eos)))
 
 (setup markdown-mode
   (:pkg t)
-  (:file-match (rx (or ".md" ".markdown" ".mdown") eos)))
+  (:match-file (rx (or ".md" ".markdown" ".mdown") eos)))
 
 (setup yaml-mode
   (:pkg t)
-  (:file-match (rx (or ".yml" ".yaml") eos)))
+  (:match-file (rx (or ".yml" ".yaml") eos)))
 
 (setup json-mode
   (:pkg t)
-  (:file-match (rx ".json" eos)))
+  (:match-file (rx ".json" eos)))
 
 (setup rustic
   (:pkg t)
-  (:file-match (rx ".rs" eos))
-  (:option rustic-format-on-save nil ; There's `format-all-mode'
+  (:match-file (rx ".rs" eos))
+  (setopt rustic-format-on-save nil ; There's `format-all-mode'
            rustic-lsp-client archer-lsp-client))
 
 (setup terraform-mode
   (:pkg t)
-  (:file-match (rx ".tf" eos)))
+  (:match-file (rx ".tf" eos)))
 
 (provide 'init-extra-modes)
 ;;; init-extra-modes.el ends here

--- a/home/mario/modules/editors/emacs/config/lisp/init-extra-modes.el
+++ b/home/mario/modules/editors/emacs/config/lisp/init-extra-modes.el
@@ -7,34 +7,27 @@
 ;;; Code:
 
 (setup cmake-mode
-  (:pkg t)
-  (:match-file (rx (or "CmakeLists.txt" ".cmake") eos)))
+  (:pkg t))
 
 (setup nix-mode
-  (:pkg t)
-  (:match-file (rx ".nix" eos)))
+  (:pkg t))
 
 (setup markdown-mode
-  (:pkg t)
-  (:match-file (rx (or ".md" ".markdown" ".mdown") eos)))
+  (:pkg t))
 
 (setup yaml-mode
-  (:pkg t)
-  (:match-file (rx (or ".yml" ".yaml") eos)))
+  (:pkg t))
 
 (setup json-mode
-  (:pkg t)
-  (:match-file (rx ".json" eos)))
+  (:pkg t))
 
 (setup rustic
   (:pkg t)
-  (:match-file (rx ".rs" eos))
   (setopt rustic-format-on-save nil ; There's `format-all-mode'
-           rustic-lsp-client archer-lsp-client))
+          rustic-lsp-client archer-lsp-client))
 
 (setup terraform-mode
-  (:pkg t)
-  (:match-file (rx ".tf" eos)))
+  (:pkg t))
 
 (provide 'init-extra-modes)
 ;;; init-extra-modes.el ends here

--- a/home/mario/modules/editors/emacs/config/lisp/init-fonts.el
+++ b/home/mario/modules/editors/emacs/config/lisp/init-fonts.el
@@ -17,22 +17,22 @@
 
 (setup fontaine
   (:pkg t)
-  (:option x-underline-at-descent-line nil
+  (setopt x-underline-at-descent-line nil
            use-default-font-for-symbols t)
 
   (unless (version< emacs-version "28")
     (setq-default text-scale-remap-header-line t))
 
-  (:option archer-font-height (pcase (system-name)
+  (setopt archer-font-height (pcase (system-name)
                                 ("quietfrost" 140)
                                 ("mate" 140)
                                 (_ 140)))
 
 
   ;; TODO: fix this, the state is not re-stored correctly.
-  ; (:option fontaine-latest-state-file (locate-user-emacs-file "var/fontaine-state.eld"))
+  ; (setopt fontaine-latest-state-file (locate-user-emacs-file "var/fontaine-state.eld"))
 
-  (:option fontaine-presets
+  (setopt fontaine-presets
            `((victor
               :default-family "VictorMono Nerd Font"
               :default-height ,archer-font-height

--- a/home/mario/modules/editors/emacs/config/lisp/init-help.el
+++ b/home/mario/modules/editors/emacs/config/lisp/init-help.el
@@ -9,7 +9,7 @@
 (setup which-key
   (:pkg t)
   (:hide-mode)
-  (:option which-key-idle-delay 0.2)
+  (setopt which-key-idle-delay 0.2)
   (which-key-mode 1))
 
 (setup helpful

--- a/home/mario/modules/editors/emacs/config/lisp/init-lsp.el
+++ b/home/mario/modules/editors/emacs/config/lisp/init-lsp.el
@@ -59,7 +59,7 @@
       (setq lsp-completion-provider :none)
       (add-hook 'lsp-completion-mode-hook #'archer-lsp-mode-setup-completion)))
 
-  (:option lsp-keymap-prefix "C-c l"
+  (setopt lsp-keymap-prefix "C-c l"
            lsp-keep-workspace-alive nil
            lsp-auto-guess-root nil
            lsp-log-io nil
@@ -91,7 +91,7 @@
   (:hook-into lsp-mode)
   (:load-after lsp)
   (:when-loaded
-    (:option lsp-ui-doc-enable t
+    (setopt lsp-ui-doc-enable t
              lsp-ui-doc-header t
              lsp-ui-doc-include-signature t
              lsp-ui-doc-border '(face-foreground 'default)

--- a/home/mario/modules/editors/emacs/config/lisp/init-mail.el
+++ b/home/mario/modules/editors/emacs/config/lisp/init-mail.el
@@ -132,7 +132,7 @@ To improve."
 (setup notmuch
   (:autoload notmuch notmuch-mua-new-mail)
   ;; UI
-  (:option notmuch-show-logo t
+  (setopt notmuch-show-logo t
            notmuch-column-control 0.5
            notmuch-hello-auto-refresh t
            notmuch-hello-recent-searches-max 15
@@ -146,7 +146,7 @@ To improve."
              notmuch-hello-insert-recent-searches
              notmuch-hello-insert-alltags))
   ;; Search
-  (:option notmuch-search-oldest-first nil
+  (setopt notmuch-search-oldest-first nil
            notmuch-show-empty-saved-searches t
            notmuch-search-result-format
            '(("date" . "%12s ")
@@ -166,7 +166,7 @@ To improve."
              ("flagged" . notmuch-search-flagged-face)))
 
   ;; Saved searches
-  (:option notmuch-saved-searches
+  (setopt notmuch-saved-searches
            ;; Personal
            `(( :name "📥 inbox (personal)"
                :query "tag:inbox and tag:personal"
@@ -187,7 +187,7 @@ To improve."
                :key ,(kbd "u u"))))
 
   ;; Tags
-  (:option notmuch-archive-tags archer-notmuch-mark-archive-tags
+  (setopt notmuch-archive-tags archer-notmuch-mark-archive-tags
            notmuch-message-replied-tags '("+replied")
            notmuch-message-forwarded-tags '("+forwarded")
            notmuch-show-mark-read-tags '("-unread")
@@ -196,7 +196,7 @@ To improve."
            notmuch-draft-save-plaintext 'ask)
 
   ;; Tag formats (with emojis)
-  (:option notmuch-tag-formats
+  (setopt notmuch-tag-formats
            '(("unread" (propertize tag 'face 'notmuch-tag-unread))
              ("flagged" (propertize tag 'face 'notmuch-tag-flagged) ;; Icon is enough
               (concat "🚩")))
@@ -212,7 +212,7 @@ To improve."
               (concat "✏️" tag))))
 
   ;; Reading
-  (:option notmuch-show-relative-dates t
+  (setopt notmuch-show-relative-dates t
            notmuch-show-all-multipart/alternative-parts nil
            notmuch-show-indent-messages-width 1
            notmuch-show-indent-multipart t
@@ -223,11 +223,11 @@ To improve."
            notmuch-message-headers '("To" "Cc" "Subject" "Date")
            notmuch-message-headers-visible t)
 
-  (:option notmuch-wash-citation-lines-prefix 3
+  (setopt notmuch-wash-citation-lines-prefix 3
            notmuch-wash-citation-lines-suffix 3)
 
   ;; TODO Composition
-  (:option notmuch-mua-compose-in 'current-window
+  (setopt notmuch-mua-compose-in 'current-window
            notmuch-mua-hidden-headers nil
            notmuch-address-command 'internal
            notmuch-always-prompt-for-sender t
@@ -242,7 +242,7 @@ To improve."
                    "pi[èe]ce\s+jointe?\\)\\b"))
 
   ;; Tagging keys
-  (:option notmuch-tagging-keys
+  (setopt notmuch-tagging-keys
            `((,(kbd "d") archer-notmuch-mark-delete-tags "⛔ Mark for deletion")
              (,(kbd "a") archer-notmuch-mark-archive-tags "📫 Mark to archive")
              (,(kbd "f") archer-notmuch-mark-flag-tags "🚩 Flag as important")
@@ -251,7 +251,7 @@ To improve."
              (,(kbd "u") ("+unread") "📔 Mark as unread")))
 
   ;; Identities
-  (:option notmuch-identies '("mario.liguori.056@gmail.com" "mario.liguori6@studenti.unina.it")
+  (setopt notmuch-identies '("mario.liguori.056@gmail.com" "mario.liguori6@studenti.unina.it")
            notmuch-fcc-dirs '(("mario.liguori.056@gmail.com" . "gmail +personal +sent")
                               ("mario.liguori6@studenti.unina.it" . "unina/sent +university +sent")))
 
@@ -262,8 +262,8 @@ To improve."
   (:with-hook notmuch-mua-send-hook
     (:hook notmuch-mua-attachment-check))
 
-  (:global "C-c m" notmuch
-           "C-x m" notmuch-mua-new-mail)
+  (keymap-global-set "C-c m" 'notmuch)
+  (keymap-global-set "C-x m" 'notmuch-mua-new-mail)
 
   (:bind-into notmuch-search
     "/" notmuch-search-filter
@@ -292,7 +292,7 @@ To improve."
   (:load-after consult notmuch))
 
 (setup sendmail
-  (:option send-mail-function 'sendmail-send-it
+  (setopt send-mail-function 'sendmail-send-it
            mail-specify-envelope-from t
            message-sendmail-envelope-from 'header
            mail-envelope-from 'header)
@@ -300,7 +300,7 @@ To improve."
     (:hook archer-lieer-sendmail)))
 
 (setup message
-  (:option message-cite-style 'message-cite-style-gmail
+  (setopt message-cite-style 'message-cite-style-gmail
            message-citation-line-function 'message-insert-formatted-citation-line))
 
 (provide 'init-mail)

--- a/home/mario/modules/editors/emacs/config/lisp/init-media.el
+++ b/home/mario/modules/editors/emacs/config/lisp/init-media.el
@@ -14,7 +14,7 @@
   (:require emms-setup)
   (emms-all)
 
-  (:option emms-mode-line t
+  (setopt emms-mode-line t
            ;; emms-source-file-default-directory "~/idkrn/"
            emms-info-asynchronously t
            emms-playing-time t

--- a/home/mario/modules/editors/emacs/config/lisp/init-modeline.el
+++ b/home/mario/modules/editors/emacs/config/lisp/init-modeline.el
@@ -35,7 +35,7 @@
 ;; <https://github.com/minad/recursion-indicator>.
 (setup recursion-indicator
   (:pkg t)
-  (:option recursion-indicator-general (concat "general" (all-the-icons-material "cached" :v-adjust -0.1))
+  (setopt recursion-indicator-general (concat "general" (all-the-icons-material "cached" :v-adjust -0.1))
            recursion-indicator-minibuffer (concat "minibuffer " (all-the-icons-material "cached" :v-adjust -0.1)))
 
   (setq-default mode-line-modes
@@ -51,14 +51,14 @@
 (setup keycast
   (:pkg t)
   ;; For `keycast-mode'
-  (:option keycast-mode-line-window-predicate #'keycast-active-frame-bottom-right-p
+  (setopt keycast-mode-line-window-predicate #'keycast-active-frame-bottom-right-p
            keycast-separator-width 1
            keycast-mode-line-remove-tail-elements nil
            keycast-mode-line-format "%3s%k%c%r"
            keycast-mode-line-insert-after 'mode-line-misc-info)
 
   ;; For `keycast-log-mode'
-  (:option keycast-log-format "%-20K%C\n"
+  (setopt keycast-log-format "%-20K%C\n"
            keycast-log-newest-first t
            keycast-log-frame-alist '((minibuffer . nil)))
 

--- a/home/mario/modules/editors/emacs/config/lisp/init-org-export.el
+++ b/home/mario/modules/editors/emacs/config/lisp/init-org-export.el
@@ -11,7 +11,7 @@
 ;; LaTeX export
 (setup ox-latex
   (:load-after ox)
-  (:option org-latex-toc-command "\\tableofcontents \\clearpage"  ; Newpage after TOC
+  (setopt org-latex-toc-command "\\tableofcontents \\clearpage"  ; Newpage after TOC
            ;; Enable listings
            org-latex-listings t
            ;; Previewing LaTeX fragments in org mode, default changed for bad quality.
@@ -47,7 +47,7 @@
 (setup ox-reveal
   (:pkg (:host github :repo "yjwen/org-reveal"))
   (:load-after ox)
-  (:option org-reveal-root "https://cdn.jsdelivr.net/npm/reveal.js"))
+  (setopt org-reveal-root "https://cdn.jsdelivr.net/npm/reveal.js"))
 
 ;; Hugo
 (setup ox-hugo

--- a/home/mario/modules/editors/emacs/config/lisp/init-org.el
+++ b/home/mario/modules/editors/emacs/config/lisp/init-org.el
@@ -17,7 +17,7 @@
 
 (setup org
   ;; General
-  (:option org-adapt-indentation nil
+  (setopt org-adapt-indentation nil
            org-fold-catch-invisible-edits 'smart
            org-cycle-separator-lines 1
            org-auto-align-tags nil
@@ -26,7 +26,7 @@
            org-startup-folded 'content
            org-insert-heading-respect-content t
            org-read-date-prefer-future 'time
-           org-startup-folded t
+           org-startup-folded 'showeverything
            org-startup-indented t
 
            ;; Prettify
@@ -85,9 +85,9 @@
   (:local-set completion-at-point-functions '(cape-dabbrev cape-file))
 
   (:with-after org-ctags
-    (:option org-ctags-open-link-functions '()))
+    (setopt org-ctags-open-link-functions '()))
 
-  (:option org-directory "~/projects/pkm"
+  (setopt org-directory "~/projects/pkm"
            org-agenda-files '("inbox.org" "todo.org")
 
            ;; Standard refiling is awful
@@ -126,7 +126,7 @@
   (:pkg t)
   (:autoload org-appear-mode)
   (:hook-into org-mode)
-  (:option org-appear-autoemphasis t
+  (setopt org-appear-autoemphasis t
            org-appear-autolinks nil
            org-appear-autosubmarkers t))
 
@@ -135,7 +135,7 @@
   (:load-after org)
   (:hook-into org-mode)
   (set-face-attribute 'org-modern-symbol nil :family "Iosevka Nerd Font")
-  (:option org-modern-label-border 1
+  (setopt org-modern-label-border 1
            org-modern-hide-stars nil      ;; Compatibility with org-indent
            org-modern-block-fringe nil    ;; Bad
            org-modern-variable-pitch nil
@@ -152,7 +152,7 @@
   (:pkg t)
   (:load-after org)
   (:hook-into org-mode)
-  (:option olivetti-body-width 0.75
+  (setopt olivetti-body-width 0.75
            olivetti-minimum-body-width 75
            olivetti-style 'fancy))
 

--- a/home/mario/modules/editors/emacs/config/lisp/init-pdf.el
+++ b/home/mario/modules/editors/emacs/config/lisp/init-pdf.el
@@ -10,14 +10,14 @@
   (:pkg (:built-in 'prefer :post-install (pdf-tools-install :no-query)))
   (:require pdf-tools)
 
-  (:option display-buffer-alist '(("^\\*outline"
+  (setopt display-buffer-alist '(("^\\*outline"
                                    display-buffer-in-side-window
                                    (side . left)
                                    (window-width . 0.20)
                                    (inhibit-switch-frame . t))))
 
   (:with-mode pdf-view-mode
-    (:file-match "\\.[pP][dD][fF]\\'")))
+    (:match-file "\\.[pP][dD][fF]\\'")))
 
 
 (setup saveplace-pdf-view

--- a/home/mario/modules/editors/emacs/config/lisp/init-pdf.el
+++ b/home/mario/modules/editors/emacs/config/lisp/init-pdf.el
@@ -14,10 +14,7 @@
                                    display-buffer-in-side-window
                                    (side . left)
                                    (window-width . 0.20)
-                                   (inhibit-switch-frame . t))))
-
-  (:with-mode pdf-view-mode
-    (:match-file "\\.[pP][dD][fF]\\'")))
+                                   (inhibit-switch-frame . t)))))
 
 
 (setup saveplace-pdf-view

--- a/home/mario/modules/editors/emacs/config/lisp/init-performance.el
+++ b/home/mario/modules/editors/emacs/config/lisp/init-performance.el
@@ -16,7 +16,7 @@
   ;; when it's idle. However, if the idle delay is too long, we run the risk of
   ;; runaway memory usage in busy sessions. If it's too low, then we may as well
   ;; not be using gcmh at all.
-  (:option gcmh-idle-delay 'auto ; Default 15 seconds
+  (setopt gcmh-idle-delay 'auto ; Default 15 seconds
            gcmh-auto-idle-delay-factor 10
            gcmh-high-cons-threshold (* 16 1024 1024))
   (gcmh-mode 1))

--- a/home/mario/modules/editors/emacs/config/lisp/init-projects.el
+++ b/home/mario/modules/editors/emacs/config/lisp/init-projects.el
@@ -16,7 +16,7 @@
   (elpaca transient)
   (elpaca (magit :wait t))
   (:autoload magit-status)
-  (:option magit-display-buffer-function 'magit-display-buffer-same-window-except-diff-v1))
+  (setopt magit-display-buffer-function 'magit-display-buffer-same-window-except-diff-v1))
 
 ;; (setup forge
 ;;   (:pkg t)
@@ -24,7 +24,7 @@
 
 (setup ediff
   (:autoload ediff-buffers ediff-files ediff-buffers3 ediff-files3)
-  (:option ediff-split-window-function 'split-window-horizontally
+  (setopt ediff-split-window-function 'split-window-horizontally
            ediff-window-setup-function 'ediff-setup-windows-plain))
 
 (setup blamer
@@ -37,12 +37,12 @@
   (:hide-mode)
 
   ;; NOTE: Set this to the folder where you keep your Git repos!
-  (:option projectile-project-search-path '("~/projects")
+  (setopt projectile-project-search-path '("~/projects")
            projectile-switch-project-action #'projectile-dired)
 
   (projectile-mode)
 
-  (:global "C-c C-p" projectile-command-map))
+  (keymap-global-set "C-c C-p" 'projectile-command-map))
 
 (setup consult-projectile
   (:disable t)
@@ -53,7 +53,7 @@
 (setup treemacs
   (:disable t)
   (:pkg t)
-  (:option treemacs-deferred-git-apply-delay        0.5
+  (setopt treemacs-deferred-git-apply-delay        0.5
            treemacs-directory-name-transformer      #'identity
            treemacs-display-in-side-window          t
            treemacs-eldoc-display                   'simple
@@ -124,13 +124,13 @@
        (treemacs-git-mode 'simple))))
 
 
-  (:global "M-0"        treemacs-select-window
-           "C-c C-t 1"  treemacs-delete-other-windows
-           "C-c C-t t"  treemacs
-           "C-c C-t d"  treemacs-select-directory
-           "C-c C-t b"  treemacs-bookmark
-           "C-c C-t f"  treemacs-find-file
-           "C-c C-t T"  treemacs-find-tag))
+  (keymap-global-set "M-0"        'treemacs-select-window)
+  (keymap-global-set "C-c C-t 1"  'treemacs-delete-other-windows)
+  (keymap-global-set "C-c C-t t"  'treemacs)
+  (keymap-global-set "C-c C-t d"  'treemacs-select-directory)
+  (keymap-global-set "C-c C-t b"  'treemacs-bookmark)
+  (keymap-global-set "C-c C-t f"  'treemacs-find-file)
+  (keymap-global-set "C-c C-t T"  'treemacs-find-tag))
 
 (setup treemacs-projectile
   (:disable t)

--- a/home/mario/modules/editors/emacs/config/lisp/init-shell.el
+++ b/home/mario/modules/editors/emacs/config/lisp/init-shell.el
@@ -11,14 +11,14 @@
 
   (:autoload vterm vterm-other-window)
 
-  (:option vterm-buffer-name-string "vterm: %s"
+  (setopt vterm-buffer-name-string "vterm: %s"
            vterm-max-scrollback 5000
            vterm-kill-buffer-on-exit t))
 
 (setup multi-vterm
   (:pkg t)
   (:with-after vterm
-    (:option multi-vterm-dedicated-window-height-percent 20)))
+    (setopt multi-vterm-dedicated-window-height-percent 20)))
 
 (provide 'init-shell)
 ;;; init-shell.el ends here

--- a/home/mario/modules/editors/emacs/config/lisp/init-snippets.el
+++ b/home/mario/modules/editors/emacs/config/lisp/init-snippets.el
@@ -21,7 +21,7 @@
 (setup yasnippet-capf
   (:pkg t)
   (:load-after cape)
-  (:global "C-c p y" cape-yasnippet))
+  (keymap-global-set "C-c p y" 'cape-yasnippet))
 
 (provide 'init-snippets)
 ;;; init-snippets.el ends here

--- a/home/mario/modules/editors/emacs/config/lisp/init-spell-and-check.el
+++ b/home/mario/modules/editors/emacs/config/lisp/init-spell-and-check.el
@@ -10,7 +10,7 @@
   ;; Dumb `flymake' made me crash for this
   (add-to-list 'elisp-flymake-byte-compile-load-path load-path)
 
-  (:option flymake-fringe-indicator-position 'left-fringe
+  (setopt flymake-fringe-indicator-position 'left-fringe
            flymake-suppress-zero-counters t
            flymake-start-on-flymake-mode t
            flymake-no-changes-timeout 0.3
@@ -18,10 +18,10 @@
            flymake-proc-compilation-prevents-syntax-check t
            flymake-wrap-around nil)
 
-  (:option flymake-mode-line-format
+  (setopt flymake-mode-line-format
            '("" flymake-mode-line-exception flymake-mode-line-counters))
 
-  (:option flymake-mode-line-counter-format
+  (setopt flymake-mode-line-counter-format
            '(" " flymake-mode-line-error-counter
              flymake-mode-line-warning-counter
              flymake-mode-line-note-counter ""))

--- a/home/mario/modules/editors/emacs/config/lisp/init-telega.el
+++ b/home/mario/modules/editors/emacs/config/lisp/init-telega.el
@@ -13,7 +13,7 @@
 
   (:autoload telega)
 
-  (:option telega-use-images t
+  (setopt telega-use-images t
            telega-emoji-font-family "Noto Color Emoji"
            telega-emoji-use-images nil
            telega-emoji-company-backend 'telega-company-emoji
@@ -31,7 +31,7 @@
 
   (:when-loaded
     (:also-load telega-mnz)
-    (:global "C-c t" telega-prefix-map))
+    (keymap-global-set "C-c t" 'telega-prefix-map))
 
   (:with-mode telega-chat-mode
     ;; (:hook archer-telega-chat-mode)

--- a/home/mario/modules/editors/emacs/config/lisp/init-tex.el
+++ b/home/mario/modules/editors/emacs/config/lisp/init-tex.el
@@ -9,8 +9,7 @@
 
 (setup auctex
   (:pkg t)
-  (:with-mode LaTeX-mode
-    (:match-file "\\.tex\\'"))
+  (add-to-list 'auto-mode-alist '("\\.tex\\'" . latex-mode))
 
   (setopt TeX-master nil
            TeX-output-dir "output"

--- a/home/mario/modules/editors/emacs/config/lisp/init-tex.el
+++ b/home/mario/modules/editors/emacs/config/lisp/init-tex.el
@@ -10,9 +10,9 @@
 (setup auctex
   (:pkg t)
   (:with-mode LaTeX-mode
-    (:file-match "\\.tex\\'"))
+    (:match-file "\\.tex\\'"))
 
-  (:option TeX-master nil
+  (setopt TeX-master nil
            TeX-output-dir "output"
            TeX-auto-save t
            TeX-parse-self t

--- a/home/mario/modules/editors/emacs/config/lisp/init-themes.el
+++ b/home/mario/modules/editors/emacs/config/lisp/init-themes.el
@@ -10,12 +10,12 @@
 (setup modus-themes
   (:pkg t)
   ;; Preferences
-  (:option modus-themes-org-blocks 'gray-background
+  (setopt modus-themes-org-blocks 'gray-background
            modus-themes-mixed-fonts nil
            modus-themes-variable-pitch-ui nil)
   
   ;; Overrides
-  (:option modus-themes-common-palette-overrides
+  (setopt modus-themes-common-palette-overrides
            ;; Modeline
            '((bg-mode-line-active bg-blue-subtle)
              (fg-mode-line-active fg-main)
@@ -90,7 +90,7 @@
 (setup circadian
   (:pkg t)
   (:load-after modus-themes)
-  (:option circadian-themes '(("8:00" . modus-operandi)
+  (setopt circadian-themes '(("8:00" . modus-operandi)
                               ("20:00" . modus-vivendi)))
   (circadian-setup))
 

--- a/home/mario/modules/editors/emacs/config/lisp/init-windows.el
+++ b/home/mario/modules/editors/emacs/config/lisp/init-windows.el
@@ -26,14 +26,14 @@
   (setq window-divider-default-places 'right-only)
   (window-divider-mode 0)
 
-  (:global "C-x <up>"   enlarge-window
-           "C-x <down>" shrink-window
-           "C-x {"      shrink-window-horizontally
-           "C-x }"      enlarge-window-horizontally))
+  (keymap-global-set "C-x <up>"   'enlarge-window)
+  (keymap-global-set "C-x <down>" 'shrink-window)
+  (keymap-global-set "C-x {"      'shrink-window-horizontally
+  (keymap-global-set "C-x }"      'enlarge-window-horizontally)))
 
 (setup beframe
   (:pkg t)
-  (:option beframe-functions-in-frames '(project-prompt-project-dir)
+  (setopt beframe-functions-in-frames '(project-prompt-project-dir)
            beframe-global-buffers '("*scratch*"
                                     "*Messages"
                                     "*Async-native-compile-log*"
@@ -62,16 +62,16 @@
 
 (setup ace-window
   (:pkg t)
-  (:global "M-o" ace-window
-           "M-O" ace-swap-window)
-  (:option aw-scope 'frame
-           aw-dispatch-always t
-           aw-minibuffer-flag t))
+  (keymap-global-set "M-o" 'ace-window)
+  (keymap-global-set "M-O" 'ace-swap-window)
+  (setopt aw-scope 'frame
+          aw-dispatch-always t
+          aw-minibuffer-flag t))
 
 (setup avy
   (:pkg t)
-  (:global "M-g j" avy-goto-char-timer)
-  (:option avy-all-windows nil   ;; only current
+  (keymap-global-set "M-g j" 'avy-goto-char-timer)
+  (setopt avy-all-windows nil   ;; only current
            avy-all-windows-alt t ;; all windows with C-u
            avy-single-candidate-jump t
            avy-case-fold-search nil

--- a/home/mario/modules/editors/emacs/config/lisp/init-windows.el
+++ b/home/mario/modules/editors/emacs/config/lisp/init-windows.el
@@ -28,8 +28,8 @@
 
   (keymap-global-set "C-x <up>"   'enlarge-window)
   (keymap-global-set "C-x <down>" 'shrink-window)
-  (keymap-global-set "C-x {"      'shrink-window-horizontally
-  (keymap-global-set "C-x }"      'enlarge-window-horizontally)))
+  (keymap-global-set "C-x {"      'shrink-window-horizontally)
+  (keymap-global-set "C-x }"      'enlarge-window-horizontally))
 
 (setup beframe
   (:pkg t)


### PR DESCRIPTION
## Changes

- Remove `:option` in favor of `setopt`, `file-match` for
`match-file`, and `:global` for `keymap-global-set`.
- Update variables where validation was failing, the packages have
been updated and now I'm rolling Emacs 30 on every machine.
- Using `keymap-global-set` is more verbose than `:global`, but I don't have
much time now to tinker.
- Remove useless `auto-mode-alist` forms included in upstream packages